### PR TITLE
Add workaround for Chrome/Chromedriver issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,17 +33,6 @@ jobs:
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/forms_runner_test"
       QUEUE_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/forms_runner_test_queue"
     steps:
-      # TODO: remove these steps once we can use latest Chrome again (see https://github.com/teamcapybara/capybara/issues/2800)
-      - uses: nanasess/setup-chromedriver@e913548694400f275b4070efcd90f47dbbc8914c # v3.0.0
-        with:
-          chromedriver-version: '128.0.6613.8600'
-          chromeapp: chrome
-      - run: |
-          sudo apt-get purge google-chrome-stable
-      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
-        with:
-          chrome-version: 128
-          install-chromedriver: 'false'
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Add or replace dependency steps here

--- a/spec/support/selenium_error_patch.rb
+++ b/spec/support/selenium_error_patch.rb
@@ -1,0 +1,34 @@
+# Monkey patch for a specific intermittent Selenium error.
+#
+# Intermittently, Selenium/Chromedriver raises `Selenium::WebDriver::Error::UnknownError`
+# with the message "Node with given id does not belong to the document".
+
+# Capybara's automatic waiting/retrying mechanism doesn't catch it,
+# leading to failure.
+#
+# We intercept the initialization of `UnknownError`. If the message matches this specific
+# case, we raise a `StaleElementReferenceError` instead. This uses Capybara's
+# retry logic which makes doesn't fail the test
+#
+# This can be removed once the following issue is resolved:
+# https://github.com/teamcapybara/capybara/issues/2800
+#
+# taken from the following issue:
+# https://github.com/teamcapybara/capybara/issues/2800#issuecomment-3049956982
+
+module Selenium
+  module WebDriver
+    module Error
+      class UnknownError
+        alias_method :old_initialize, :initialize
+        def initialize(msg = nil)
+          if msg&.include?("Node with given id does not belong to the document")
+            raise StaleElementReferenceError, msg
+          end
+
+          old_initialize(msg)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/bFuui8d7/3458-unpin-alpine-version-in-forms-e2e-tests-once-chromedriver-issue-is-fixed <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

[Capybara issue 2800](https://github.com/teamcapybara/capybara/issues/2800) has still not been resolved upstream in Chrome, or in Chromedriver, Selenium, or Capybara.

In our tests in GitHub Actions we were pinning Chrome to a version not affected by this, but that version is getting quite old. We would like to stop pinning the version of Chrome.

Instead this PR cherry-picks the Capybara workaround we've used in other repos to make Capybara treat this error as retryable, hopefully preventing the errors from surfacing. This PR then also unpins Chrome in our CI tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
