### PR TITLE
Add default S3 submission role ARN for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You will also need to run the [forms-admin service](https://github.com/govuk-for
 
 #### Getting AWS credentials
 
-If you have access to the `readonly` role in the development environment can start the Rails server, locally, with the same set of permissions in use in the development AWS account. This allows you to test features like file upload to AWS S3 and sending emails via AWS SES.
+If you have access to the `readonly` role in the development environment can start the Rails server, locally, with the same set of permissions in use in the development AWS account. This allows you to test features like file upload to AWS S3, sending emails via AWS SES, and sending submissions via AWS S3.
 
 1. Assume the `readonly` role in the development AWS account:
     ```

--- a/config/initializers/aws_role_usage.rb
+++ b/config/initializers/aws_role_usage.rb
@@ -18,7 +18,7 @@ if Rails.env.development? && ENV["ASSUME_DEV_IAM_ROLE"]
 
     assumed_role = sts.assume_role({
       role_arn: "arn:aws:iam::498160065950:role/dev-forms-runner-ecs-task",
-      role_session_name: "#{ENV['USER']}-forms-runner-local",
+      role_session_name: "#{ENV['AWS_USER'].presence || ENV['USER']}-forms-runner-local",
     })
 
     ENV["AWS_ACCESS_KEY_ID"] = assumed_role.credentials.access_key_id

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,6 +4,7 @@ active_record_encryption:
   key_derivation_salt: k7cODzIzpjWkKKGqVnabRzXtTgLnT813
 
 aws:
+  s3_submission_iam_role_arn: arn:aws:iam::498160065950:role/govuk-forms-submissions-to-s3-dev
   file_upload_s3_bucket_name: govuk-forms-dev-file-upload
   ses_submission_email_configuration_set_name: bounces_and_complaints_handling_rule
   ses_confirmation_email_configuration_set_name: bounces_and_complaints_handling_rule


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When running forms-runner locally, we want to be able to test S3 submissions. Using the `ASSUME_DEV_IAM_ROLE` flag allows that, but only when the S3 submissions role in the development environment is also provided. The role ARN is defined in forms-deploy [[1]], but using it locally is not well documented.

This commit adds the role ARN to the default configuration for local development. This should make it possible to test S3 submissions just by using the `ASSUME_DEV_IAM_ROLE` feature without further configuration.

[1]: https://github.com/govuk-forms/forms-deploy/blob/a12f9395bf84e9e66ea458b396f7867ce4c9f84d/infra/modules/forms-runner/submissions-to-s3.tf#L2


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
