### PR TITLE
Add exit page model

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -4,6 +4,7 @@ class Condition
   delegate(
     :id,
     :answer_value,
+    :exit_page_id,
     :exit_page_heading,
     :exit_page_markdown,
     :validation_errors,
@@ -43,7 +44,7 @@ class Condition
   def exit_page?
     return false unless form_document_condition.respond_to?(:exit_page_markdown)
 
-    form_document_condition.exit_page_markdown.is_a?(String)
+    form_document_condition.try(:exit_page_id).present? || form_document_condition.exit_page_markdown.is_a?(String)
   end
 
   def skip_to_end?

--- a/app/models/exit_page.rb
+++ b/app/models/exit_page.rb
@@ -1,0 +1,23 @@
+class ExitPage
+  attr_reader :id, :heading, :markdown
+
+  def initialize(id:, heading:, markdown:)
+    @id = id
+    @heading = heading
+    @markdown = markdown
+  end
+
+  def self.from_form_document(form_document_exit_page)
+    new(
+      id: form_document_exit_page.id,
+      heading: form_document_exit_page.heading,
+      markdown: form_document_exit_page.markdown,
+    )
+  end
+
+  def ==(other)
+    super ||
+      other.class == self.class &&
+        other.id == id
+  end
+end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -29,6 +29,15 @@ class Step
     form_document_step.next_step_id.present? ? form_document_step.next_step_id.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG
   end
 
+  def exit_pages
+    @exit_pages ||=
+      if form_document_step.respond_to?(:exit_pages)
+        form_document_step.exit_pages.map { ExitPage.from_form_document(it) }
+      else
+        []
+      end
+  end
+
   def routing_conditions
     @routing_conditions ||=
       if form_document_step.respond_to?(:routing_conditions)

--- a/spec/factories/v2_condition.rb
+++ b/spec/factories/v2_condition.rb
@@ -26,11 +26,18 @@ FactoryBot.define do
     end
 
     trait :with_exit_page do
+      transient do
+        exit_page { build(:v2_exit_page) }
+      end
+
       goto_page_id { nil }
       skip_to_end { false }
 
-      exit_page_heading { Faker::Lorem.sentence }
-      exit_page_markdown { Faker::Lorem.paragraph }
+      exit_page_id { exit_page.id }
+
+      # old-style exit page attributes
+      exit_page_heading { exit_page.heading }
+      exit_page_markdown { exit_page.markdown }
     end
   end
 end

--- a/spec/factories/v2_exit_page.rb
+++ b/spec/factories/v2_exit_page.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :v2_exit_page, class: ActiveResource::Base do
+    sequence(:id) { |n| n }
+
+    heading { Faker::Lorem.sentence }
+    markdown { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/factories/v2_step.rb
+++ b/spec/factories/v2_step.rb
@@ -80,6 +80,20 @@ FactoryBot.define do
                   .new(none_of_the_above_question_text, none_of_the_above_question_is_optional)
           end
         end
+
+        trait :with_exit_page do
+          transient do
+            exit_page { build(:v2_exit_page) }
+          end
+
+          exit_pages { [exit_page] }
+
+          routing_conditions do
+            [
+              build(:v2_condition, :with_exit_page, exit_page:),
+            ]
+          end
+        end
       end
 
       trait :with_text_settings do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -145,6 +145,19 @@ RSpec.describe Condition do
       end
     end
 
+    context "when condition has exit_page_id" do
+      let(:form_document_condition) do
+        build(
+          :v2_condition,
+          exit_page_id: 10,
+        )
+      end
+
+      it "returns true" do
+        expect(condition.exit_page?).to be true
+      end
+    end
+
     context "when condition has exit page content" do
       let(:form_document_condition) do
         build(

--- a/spec/models/exit_page_spec.rb
+++ b/spec/models/exit_page_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe ExitPage do
+  describe "#initialize" do
+    it "sets the attributes" do
+      exit_page = described_class.new(
+        id: 1,
+        heading: "You are not elegible for this service",
+        markdown: "Here’s what to do next: ...",
+      )
+
+      expect(exit_page).to have_attributes(
+        id: 1,
+        heading: "You are not elegible for this service",
+        markdown: "Here’s what to do next: ...",
+      )
+    end
+  end
+
+  describe ".from_form_document" do
+    it "creates an exit page from a form document object" do
+      form_document_exit_page = build(:v2_exit_page)
+      exit_page = described_class.from_form_document(form_document_exit_page)
+
+      expect(exit_page).to be_an described_class
+      expect(exit_page).to have_attributes(
+        id: form_document_exit_page.id,
+        heading: form_document_exit_page.heading,
+        markdown: form_document_exit_page.markdown,
+      )
+    end
+  end
+
+  describe "#==" do
+    context "when other exit page was created from the same form document exit page" do
+      it "returns true" do
+        form_document_exit_page = build(:v2_exit_page)
+        exit_page = described_class.from_form_document(form_document_exit_page)
+        other_exit_page = described_class.from_form_document(form_document_exit_page)
+
+        expect(exit_page == other_exit_page).to be true
+      end
+    end
+
+    context "when other exit page was created from a different form document exit page" do
+      it "returns false" do
+        form_document_exit_page = build(:v2_exit_page)
+        exit_page = described_class.from_form_document(form_document_exit_page)
+        other_form_document_exit_page = build(:v2_exit_page)
+        other_exit_page = described_class.from_form_document(other_form_document_exit_page)
+
+        expect(exit_page == other_exit_page).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/0ijhpyt8/3146-update-forms-runner-to-work-with-more-than-one-exit-page-for-a-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR adds an `ExitPage` model that works with new-style exit pages in a form document.

Currently we don't use the new exit page model for anything, so this shouldn't affect production, it's just laying preparatory ground work.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
