### PR TITLE
Update exit page controller to use new-style exit pages

### DIFF
--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -5,6 +5,7 @@ module Forms
 
       @back_link = form_step_path(@form.id, @form.form_slug, @step.id)
       @condition = @step.routing_conditions.first
+      @exit_page = @step.exit_pages.find { it.id == @condition.exit_page_id }
     end
   end
 end

--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -1,11 +1,14 @@
 module Forms
   class ExitPagesController < StepController
     def show
-      return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug) unless current_context.can_visit?(@step.id)
+      unless current_context.can_visit?(@step.id) && @step.exit_page_condition_matches?
+        return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug)
+      end
 
       @back_link = form_step_path(@form.id, @form.form_slug, @step.id)
       @condition = @step.routing_conditions.first
       @exit_page = @step.exit_pages.find { it.id == @condition.exit_page_id }
+      raise KeyError, "Couldn't find ExitPage with id=#{@condition.exit_page_id}" if @exit_page.nil?
     end
   end
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -4,7 +4,6 @@ class Condition
   delegate(
     :id,
     :answer_value,
-    :exit_page_id,
     :exit_page_heading,
     :exit_page_markdown,
     :validation_errors,
@@ -29,6 +28,10 @@ class Condition
 
   def goto_page_id
     form_document_condition.goto_page_id.to_s
+  end
+
+  def exit_page_id
+    form_document_condition.exit_page_id.to_s
   end
 
   def default?

--- a/app/models/exit_page.rb
+++ b/app/models/exit_page.rb
@@ -2,7 +2,7 @@ class ExitPage
   attr_reader :id, :heading, :markdown
 
   def initialize(id:, heading:, markdown:)
-    @id = id
+    @id = id.to_s
     @heading = heading
     @markdown = markdown
   end

--- a/app/views/forms/exit_pages/show.html.erb
+++ b/app/views/forms/exit_pages/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form.name, page_name: @condition.exit_page_heading, mode: @mode)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: @exit_page.heading, mode: @mode)) %>
 
 <% content_for :back_link do %>
   <%= link_to t("forms.back"), @back_link, class: "govuk-back-link" %>
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"> <%= @condition.exit_page_heading %></h1>
-    <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@condition.exit_page_markdown) %>
+    <h1 class="govuk-heading-l"> <%= @exit_page.heading %></h1>
+    <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@exit_page.markdown) %>
     <%= render SupportDetailsComponent::View.new(@support_details) %>
   </div>
 </div>

--- a/spec/factories/v2_step.rb
+++ b/spec/factories/v2_step.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     next_step_id { nil }
 
+    exit_pages { [] }
     routing_conditions { [] }
 
     type { nil }

--- a/spec/features/fill_in_form_with_exit_page_spec.rb
+++ b/spec/features/fill_in_form_with_exit_page_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 feature "Fill in and submit a form with an exit page", type: :feature do
-  let(:routing_conditions) { [build(:v2_condition, :with_exit_page, routing_page_id: 1, answer_value: "Option 1", exit_page_heading: "This is an exit_page", exit_page_markdown: "This is the contents")] }
-  let(:steps) { [build(:v2_selection_question_step, id: 1, routing_conditions:, question_text:)] }
+  let(:exit_page) { build(:v2_exit_page, heading: "This is an exit_page", markdown: "This is the contents") }
+  let(:routing_conditions) { [build(:v2_condition, :with_exit_page, routing_page_id: 1, answer_value: "Option 1", exit_page:)] }
+  let(:steps) { [build(:v2_selection_question_step, :with_exit_page, id: 1, routing_conditions:, question_text:, exit_page:)] }
   let(:form) { build :v2_form_document, :live, form_id: 1, name: "Fill in this form", steps:, start_page: 1, send_copy_of_answers: "enabled" }
   let(:question_text) { Faker::Lorem.question }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }

--- a/spec/models/exit_page_spec.rb
+++ b/spec/models/exit_page_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe ExitPage do
   describe "#initialize" do
     it "sets the attributes" do
       exit_page = described_class.new(
-        id: 1,
+        id: "1",
         heading: "You are not elegible for this service",
         markdown: "Here’s what to do next: ...",
       )
 
       expect(exit_page).to have_attributes(
-        id: 1,
+        id: "1",
         heading: "You are not elegible for this service",
         markdown: "Here’s what to do next: ...",
       )
@@ -24,7 +24,7 @@ RSpec.describe ExitPage do
 
       expect(exit_page).to be_an described_class
       expect(exit_page).to have_attributes(
-        id: form_document_exit_page.id,
+        id: form_document_exit_page.id.to_s,
         heading: form_document_exit_page.heading,
         markdown: form_document_exit_page.markdown,
       )

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
     end
 
+    context "when the question with an exit page has been answered and the exit page should not be shown" do
+      let(:answer) { "Option 2" }
+
+      it "redirects to the next unanswered question" do
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+      end
+    end
+
     context "when the form filler has not answered any questions" do
       let(:store) { { answers: {} } }
 
@@ -50,6 +59,28 @@ RSpec.describe Forms::ExitPagesController, type: :request do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
         expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: first_step_in_form.id)
       end
+    end
+
+    context "when the step does not have an exit page" do
+      let(:step_without_exit_page) { build(:v2_selection_question_step, id: 2, next_step_id: 3) }
+      let(:step_with_exit_page) { step_without_exit_page }
+
+      it "redirects to the next unanswered question" do
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)
+        expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+      end
+    end
+  end
+
+  context "when the exit page is missing from the form document" do
+    let(:condition_with_exit_page) { build(:v2_condition, :with_exit_page, routing_page_id: 2, exit_page:) }
+    let(:step_without_exit_page) { build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3) }
+    let(:step_with_exit_page) { step_without_exit_page }
+
+    it "raises an error" do
+      expect {
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+      }.to raise_error(/Couldn't find ExitPage/)
     end
   end
 end

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
     it "renders an exit page" do
       get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
       expect(response).to render_template(:show)
+      expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
     end
 
     context "when the form filler has not answered any questions" do

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Forms::ExitPagesController, type: :request do
+  let(:exit_page) { build(:v2_exit_page) }
+  let(:steps) { [first_step_in_form, step_with_exit_page, next_step_in_form] }
+  let(:first_step_in_form) { build(:v2_question_step, :with_text_settings, id: 1, next_step_id: 2) }
+  let(:step_with_exit_page) { build(:v2_selection_question_step, :with_exit_page, id: 2, next_step_id: 3, exit_page:) }
+  let(:next_step_in_form) { build(:v2_question_step, id: 3, next_step_id: nil) }
+  let(:form) { build(:v2_form_document, steps:, start_page: 1) }
+
+  let(:answer) { "Option 1" }
+
+  let(:store) do
+    {
+      answers: {
+        form.form_id.to_s => {
+          first_step_in_form.id.to_s => { text: "first answer" },
+          step_with_exit_page.id.to_s => { selection: answer },
+        },
+      },
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v2/forms/#{form.form_id}/live", { "Accept" => "application/json" }, form.to_json, 200
+    end
+
+    allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, **kwargs|
+      original_method.call(**kwargs, store:)
+    end
+  end
+
+  describe "GET #show" do
+    it "returns http success" do
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "renders an exit page" do
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+      expect(response).to render_template(:show)
+    end
+
+    context "when the form filler has not answered any questions" do
+      let(:store) { { answers: {} } }
+
+      it "redirects to the start of the form" do
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: first_step_in_form.id)
+      end
+    end
+  end
+end

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -1049,12 +1049,14 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
     end
 
     context "when the page is a an exit question" do
+      let(:exit_page) { build(:v2_exit_page, heading: "Exit page heading", markdown: "Exit page markdown") }
       let(:first_step_in_form) do
-        build :v2_selection_question_step,
+        build(:v2_selection_question_step,
+              :with_exit_page,
               id: 1,
               next_step_id: 2,
-              routing_conditions: [build(:v2_condition, :with_exit_page, id: 1, routing_page_id: 1, check_page_id: 1, answer_value: "Option 1", exit_page_markdown: "Exit page markdown", exit_page_heading: "exit page heading")],
-              is_optional: false
+              is_optional: false,
+              exit_page:)
       end
 
       it "redirects to the exit page when exit page answer given" do

--- a/spec/views/forms/exit_pages/show.html.erb_spec.rb
+++ b/spec/views/forms/exit_pages/show.html.erb_spec.rb
@@ -1,17 +1,24 @@
 require "rails_helper"
 
 describe "forms/exit_pages/show.html.erb" do
+  let(:exit_page) do
+    ExitPage.new(
+      id: 99,
+      heading: "heading",
+      markdown: "  * first line\n  * second line\n",
+    )
+  end
+
   let(:form) { build :form, :with_support, name: "exit page form" }
   let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
-  let(:condition) { build(:v2_condition, :with_exit_page, exit_page_heading: "heading", exit_page_markdown: "  * first line\n  * second line\n") }
   let(:support_details) { OpenStruct.new(email: form.support_email) }
 
   before do
     assign(:current_context, OpenStruct.new(form:))
     assign(:mode, mode)
-    assign(:condition, condition)
     assign(:back_link, "/back")
     assign(:support_details, support_details)
+    assign(:exit_page, exit_page)
 
     render
   end
@@ -25,7 +32,7 @@ describe "forms/exit_pages/show.html.erb" do
   end
 
   it "has the correct heading" do
-    expect(rendered).to have_css("h1", text: condition.exit_page_heading)
+    expect(rendered).to have_css("h1", text: exit_page.heading)
   end
 
   it "displays the markdown" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/0ijhpyt8/3146-update-forms-runner-to-work-with-more-than-one-exit-page-for-a-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR updates the `exit_page#show` action to work with new-style exit pages. The code still assumes that an question with an exit page has only one exit page and only one routing condition, but this PR does most of the changes needed to make the exit page controller work with multiple exit pages. We just need to make some more changes to the step model and the step controller before we can fully support more than one exit page per question in forms-runner.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
