### PR TITLE
Bump omniauth-govuk-one-login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem "rails-i18n", "~> 8.1"
 # IDNA conversion needed for validating email addresses
 gem "uri-idna"
 
-gem "omniauth_govuk_one_login", github: "OfficeForProductSafetyAndStandards/omniauth-govuk-one-login", ref: "6c6b68e186bd7ae08d6c16b8983ddad1eeb6cfc7"
+gem "omniauth_govuk_one_login", github: "OfficeForProductSafetyAndStandards/omniauth-govuk-one-login", ref: "e9ab43642508bef8c74cb0a3d4f6f0d2331c2f27"
 gem "omniauth-rails_csrf_protection"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: https://github.com/OfficeForProductSafetyAndStandards/omniauth-govuk-one-login.git
-  revision: 6c6b68e186bd7ae08d6c16b8983ddad1eeb6cfc7
-  ref: 6c6b68e186bd7ae08d6c16b8983ddad1eeb6cfc7
+  revision: e9ab43642508bef8c74cb0a3d4f6f0d2331c2f27
+  ref: e9ab43642508bef8c74cb0a3d4f6f0d2331c2f27
   specs:
     omniauth_govuk_one_login (1.7.0)
       faraday (~> 2.13)


### PR DESCRIPTION
This includes a commit ([e9ab43642508bef8c74cb0a3d4f6f0d2331c2f27](https://github.com/OfficeForProductSafetyAndStandards/omniauth-govuk-one-login/commit/e9ab43642508bef8c74cb0a3d4f6f0d2331c2f27)) which should stop some unexpected errors being raised when a request is made directly to the callback URL. Instead a more meaninful error should be raised that we can handle.