### PR TITLE
Fix exit pages controller for form documents with exit page attributes but old-style exit pages

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -45,7 +45,7 @@ class Condition
   end
 
   def new_style_exit_page?
-    form_document_condition.respond_to?(:exit_page_id)
+    !!form_document_condition.try(:exit_page_id)
   end
 
   def exit_page?

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -164,13 +164,23 @@ RSpec.describe Condition do
   end
 
   describe "#new_style_exit_page?" do
-    context "when condition has exit_page_id attribute" do
+    context "when condition has exit_page_id attribute and it is set" do
       let(:form_document_condition) do
-        build(:v2_condition, exit_page_id: nil)
+        build(:v2_condition, exit_page_id: 10)
       end
 
       it "returns true" do
         expect(condition.new_style_exit_page?).to be true
+      end
+    end
+
+    context "when condition has exit_page_id attribute and it is nil" do
+      let(:form_document_condition) do
+        build(:v2_condition, exit_page_id: nil)
+      end
+
+      it "returns false" do
+        expect(condition.new_style_exit_page?).to be false
       end
     end
 

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -84,6 +84,32 @@ RSpec.describe Forms::ExitPagesController, type: :request do
     end
   end
 
+  context "when the form document is using old-style exit pages but has new-style exit page attributes" do
+    let(:exit_page_heading) { Faker::Lorem.sentence }
+    let(:exit_page_markdown) { Faker::Lorem.paragraph }
+
+    let(:condition_with_exit_page) do
+      condition = build(:v2_condition, routing_page_id: 2, goto_page_id: nil, skip_to_end: nil, exit_page_id: nil, exit_page_heading:, exit_page_markdown:)
+      condition
+    end
+
+    let(:step_without_exit_page) do
+      step = build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3)
+      step
+    end
+
+    let(:step_with_exit_page) { step_without_exit_page }
+
+    it "falls back to the exit page content in the condition" do
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+      expect(response).to render_template(:show)
+      expect(assigns(:exit_page)).to have_attributes(
+        heading: exit_page_heading,
+        markdown: exit_page_markdown,
+      )
+    end
+  end
+
   context "when the form document is using old-style exit pages" do
     let(:exit_page_heading) { Faker::Lorem.sentence }
     let(:exit_page_markdown) { Faker::Lorem.paragraph }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/0ijhpyt8/3146-update-forms-runner-to-work-with-more-than-one-exit-page-for-a-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This attempts to fix Sentry issue https://govuk-forms.sentry.io/issues/7669549204.

We have some form documents which have the new-style exit page `exit_page_id` and `exit_pages` attributes, but only use the old-style exit page attributes. These were causing errors in production, this commit should make the exit pages controller work by falling back to the old-style exit page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
