### PR TITLE
Don't send CallbackStateMismatchError to Sentry

### DIFF
--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -4,7 +4,8 @@ module Users
 
     rescue_from AuthService::DataMissingError, FailureError do |exception|
       CurrentRequestLoggingAttributes.rescued_exception = [exception.class.name, exception.message]
-      Sentry.capture_exception(exception)
+
+      Sentry.capture_exception(exception) unless suppress_error?(exception)
 
       link_url = copy_of_answers_path(**auth_service.form_path_params)
       locale = auth_service.form_path_params[:locale] || I18n.default_locale
@@ -27,7 +28,11 @@ module Users
 
     def failure
       error = request.env["omniauth.error"]
-      raise FailureError, error
+      if error.is_a? Exception
+        raise FailureError, error.message, cause: error
+      else
+        raise FailureError, error
+      end
     end
 
     def logged_out
@@ -38,6 +43,13 @@ module Users
     rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError => e
       CurrentRequestLoggingAttributes.rescued_exception = [e.class.name, e.message]
       redirect_to :unknown_form_submitted
+    end
+
+  private
+
+    def suppress_error?(exception)
+      # CallbackStateMismatchError is raised when a request is made to the callback URL without the expected parameters.
+      exception.cause&.instance_of?(OmniAuth::GovukOneLogin::CallbackStateMismatchError)
     end
   end
 end

--- a/spec/requests/users/omniauth_controller_spec.rb
+++ b/spec/requests/users/omniauth_controller_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe Users::OmniauthController, type: :request do
   end
 
   describe "GET #failure", :capture_logging do
-    let(:error_message) { "an error message" }
+    let(:error) { StandardError.new("An error") }
 
     before do
       allow(Sentry).to receive(:capture_exception)
-      get omniauth_failure_path, env: { "omniauth.error" => error_message }
+      get omniauth_failure_path, env: { "omniauth.error" => error }
     end
 
     context "when the return from one login params are present on the session" do
@@ -146,13 +146,33 @@ RSpec.describe Users::OmniauthController, type: :request do
       end
 
       it "logs the error" do
-        expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error_message])
+        expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error.message])
       end
 
       it "sends the error to Sentry" do
         expect(Sentry).to have_received(:capture_exception).with(
           an_instance_of(Users::OmniauthController::FailureError),
         )
+      end
+
+      context "and the error is a CallbackStateMismatchError" do
+        let(:error) { OmniAuth::GovukOneLogin::CallbackStateMismatchError.new "Callback state mismatch" }
+
+        it "logs the error" do
+          expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error.message])
+        end
+
+        it "does not send the error to Sentry" do
+          expect(Sentry).not_to have_received(:capture_exception)
+        end
+      end
+
+      context "and the error is not an Exception" do
+        let(:error) { "A message" }
+
+        it "logs the error" do
+          expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error])
+        end
       end
     end
 
@@ -163,7 +183,7 @@ RSpec.describe Users::OmniauthController, type: :request do
       end
 
       it "logs the error" do
-        expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error_message])
+        expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error.message])
       end
 
       it "sends the error to Sentry" do


### PR DESCRIPTION
A OmniAuth::GovukOneLogin::CallbackStateMismatchError is raised by the omniauth-govuk-one-login gem when a request is made to the Omniauth callback URL without the required params.

This happens fairly regularly, as this URL is public and discoverable. Handle the error by logging it but don't send it to Sentry as there's nothing we need to do in response.