### PR TITLE
Add exit page id to exit page path

### DIFF
--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -14,6 +14,11 @@ module Forms
       @condition = @step.routing_conditions.first
 
       if @condition.new_style_exit_page?
+        # TODO: Revert the following lines once they have been fully deployed to production.
+        # They're a fallback to handle a zero-downtime deploy but should not be needed otherwise.
+        params[:exit_page_id] = @condition.exit_page_id if params[:exit_page_id].nil?
+        CurrentRequestLoggingAttributes.exit_page_id = params[:exit_page_id]
+
         unless @condition.exit_page_id == params[:exit_page_id]
           return redirect_to exit_page_path(@form.id, @form.form_slug, @step.id, @condition.exit_page_id)
         end

--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -1,5 +1,10 @@
 module Forms
   class ExitPagesController < StepController
+    def set_request_logging_attributes
+      super
+      CurrentRequestLoggingAttributes.exit_page_id = params[:exit_page_id]
+    end
+
     def show
       unless current_context.can_visit?(@step.id) && @step.exit_page_condition_matches?
         return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug)

--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -9,9 +9,17 @@ module Forms
       @condition = @step.routing_conditions.first
 
       if @condition.new_style_exit_page?
+        unless @condition.exit_page_id == params[:exit_page_id]
+          return redirect_to exit_page_path(@form.id, @form.form_slug, @step.id, @condition.exit_page_id)
+        end
+
         @exit_page = @step.exit_pages.find { it.id == @condition.exit_page_id }
         raise KeyError, "Couldn't find ExitPage with id=#{@condition.exit_page_id}" if @exit_page.nil?
       else
+        if params[:exit_page_id]
+          raise ActionController::RoutingError, "Exit page ID param provided for form with old-style exit pages"
+        end
+
         @exit_page = ExitPage.new(
           id: nil,
           heading: @condition.exit_page_heading,

--- a/app/controllers/forms/step_controller.rb
+++ b/app/controllers/forms/step_controller.rb
@@ -100,7 +100,11 @@ module Forms
 
     def redirect_post_save
       return redirect_to review_file_page, success: t("banner.success.file_uploaded") if @step.answered_file_question?
-      return redirect_to exit_page_path(form_id: @form.id, form_slug: @form.form_slug, step_slug: @step.id) if @step.exit_page_condition_matches?
+
+      if @step.exit_page_condition_matches?
+        @condition = @step.routing_conditions.first
+        return redirect_to exit_page_path(form_id: @form.id, form_slug: @form.form_slug, step_slug: @step.id, exit_page_id: @condition.exit_page_id)
+      end
 
       redirect_to next_page
     end

--- a/app/models/current_request_logging_attributes.rb
+++ b/app/models/current_request_logging_attributes.rb
@@ -15,7 +15,8 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
             :rescued_exception,
             :rescued_exception_trace,
             :validation_errors,
-            :answer_metadata
+            :answer_metadata,
+            :exit_page_id
 
   def as_hash
     {
@@ -36,6 +37,7 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       rescued_exception_trace:,
       validation_errors:,
       answer_metadata:,
+      exit_page_id:,
     }.compact
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
       answer_constraints = { answer_index: /\d+/ }
       step_answer_defaults = { answer_index: 1 }
 
-      get "/:step_slug/exit" => "forms/exit_pages#show",
+      get "/:step_slug/exit/(:exit_page_id)" => "forms/exit_pages#show",
           as: :exit_page,
           constraints: step_constraints
 

--- a/spec/models/current_request_logging_attributes_spec.rb
+++ b/spec/models/current_request_logging_attributes_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
       current.rescued_exception_trace = "a trace"
       current.validation_errors = ["text: blank"]
       current.answer_metadata = { foo: "bar" }
+      current.exit_page_id = 4
 
       expect(current.as_hash).to eq({
         request_host: "www.example.com",
@@ -46,6 +47,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
         rescued_exception_trace: "a trace",
         validation_errors: ["text: blank"],
         answer_metadata: { foo: "bar" },
+        exit_page_id: 4,
       })
     end
 

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -97,10 +97,12 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       end
     end
 
-    context "when the request path does not include an exit page id" do
-      it "redirects to the correct exit page path" do
+    context "when the request path does not include an exit page id", :capture_logging do
+      it "falls back to the old behaviour and renders the exit page for the matching condition" do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+        expect(response).to render_template(:show)
+        expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
+        expect(log_lines.last["exit_page_id"]).to eq exit_page.id.to_s
       end
     end
 

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
   describe "GET #show" do
     it "returns http success" do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
       expect(response).to have_http_status(:success)
     end
 
     it "renders an exit page" do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
       expect(response).to render_template(:show)
       expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
     end
@@ -47,8 +47,15 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       let(:answer) { "Option 2" }
 
       it "redirects to the next unanswered question" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
         expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+      end
+
+      context "when the request path does not include an exit page id" do
+        it "redirects to the next unanswered question" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+        end
       end
     end
 
@@ -56,8 +63,15 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       let(:store) { { answers: {} } }
 
       it "redirects to the start of the form" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
         expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: first_step_in_form.id)
+      end
+
+      context "when the request path does not include an exit page id" do
+        it "redirects to the start of the form" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: first_step_in_form.id)
+        end
       end
     end
 
@@ -66,8 +80,38 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       let(:step_with_exit_page) { step_without_exit_page }
 
       it "redirects to the next unanswered question" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id, exit_page_id: exit_page.id)
         expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+      end
+
+      context "when the request path does not include an exit page id" do
+        it "redirects to the next unanswered question" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)
+          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+        end
+      end
+    end
+
+    context "when the request path does not include an exit page id" do
+      it "redirects to the correct exit page path" do
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+      end
+    end
+
+    context "when the step does not have an exit page with the given id" do
+      it "redirects to the correct exit page path" do
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 99_999)
+        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+      end
+
+      context "when the question with an exit page has been answered and the exit page should not be shown" do
+        let(:answer) { "Option 2" }
+
+        it "redirects to the next unanswered question" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 99_999)
+          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+        end
       end
     end
 
@@ -78,7 +122,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
       it "raises an error" do
         expect {
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
         }.to raise_error(/Couldn't find ExitPage/)
       end
     end
@@ -107,6 +151,13 @@ RSpec.describe Forms::ExitPagesController, type: :request do
           markdown: exit_page_markdown,
         )
       end
+
+      context "when the request path includes an exit page id" do
+        it "returns http not found" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 1)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
 
     context "when the form document is using old-style exit pages" do
@@ -134,6 +185,13 @@ RSpec.describe Forms::ExitPagesController, type: :request do
           heading: exit_page_heading,
           markdown: exit_page_markdown,
         )
+      end
+
+      context "when the request path includes an exit page id" do
+        it "returns http not found" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 1)
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
   end

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
     end
 
+    it "logs the exit page id", :capture_logging do
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+      expect(log_lines.last["exit_page_id"]).to eq exit_page.id.to_s
+    end
+
     context "when the question with an exit page has been answered and the exit page should not be shown" do
       let(:answer) { "Option 2" }
 

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -70,71 +70,71 @@ RSpec.describe Forms::ExitPagesController, type: :request do
         expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
       end
     end
-  end
 
-  context "when the exit page is missing from the form document" do
-    let(:condition_with_exit_page) { build(:v2_condition, :with_exit_page, routing_page_id: 2, exit_page:) }
-    let(:step_without_exit_page) { build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3) }
-    let(:step_with_exit_page) { step_without_exit_page }
+    context "when the exit page is missing from the form document" do
+      let(:condition_with_exit_page) { build(:v2_condition, :with_exit_page, routing_page_id: 2, exit_page:) }
+      let(:step_without_exit_page) { build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3) }
+      let(:step_with_exit_page) { step_without_exit_page }
 
-    it "raises an error" do
-      expect {
+      it "raises an error" do
+        expect {
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        }.to raise_error(/Couldn't find ExitPage/)
+      end
+    end
+
+    context "when the form document is using old-style exit pages but has new-style exit page attributes" do
+      let(:exit_page_heading) { Faker::Lorem.sentence }
+      let(:exit_page_markdown) { Faker::Lorem.paragraph }
+
+      let(:condition_with_exit_page) do
+        condition = build(:v2_condition, routing_page_id: 2, goto_page_id: nil, skip_to_end: nil, exit_page_id: nil, exit_page_heading:, exit_page_markdown:)
+        condition
+      end
+
+      let(:step_without_exit_page) do
+        step = build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3)
+        step
+      end
+
+      let(:step_with_exit_page) { step_without_exit_page }
+
+      it "falls back to the exit page content in the condition" do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-      }.to raise_error(/Couldn't find ExitPage/)
-    end
-  end
-
-  context "when the form document is using old-style exit pages but has new-style exit page attributes" do
-    let(:exit_page_heading) { Faker::Lorem.sentence }
-    let(:exit_page_markdown) { Faker::Lorem.paragraph }
-
-    let(:condition_with_exit_page) do
-      condition = build(:v2_condition, routing_page_id: 2, goto_page_id: nil, skip_to_end: nil, exit_page_id: nil, exit_page_heading:, exit_page_markdown:)
-      condition
+        expect(response).to render_template(:show)
+        expect(assigns(:exit_page)).to have_attributes(
+          heading: exit_page_heading,
+          markdown: exit_page_markdown,
+        )
+      end
     end
 
-    let(:step_without_exit_page) do
-      step = build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3)
-      step
-    end
+    context "when the form document is using old-style exit pages" do
+      let(:exit_page_heading) { Faker::Lorem.sentence }
+      let(:exit_page_markdown) { Faker::Lorem.paragraph }
 
-    let(:step_with_exit_page) { step_without_exit_page }
+      let(:condition_with_exit_page) do
+        condition = build(:v2_condition, routing_page_id: 2, goto_page_id: nil, skip_to_end: nil, exit_page_id: nil, exit_page_heading:, exit_page_markdown:)
+        condition.attributes.delete(:exit_page_id)
+        condition
+      end
 
-    it "falls back to the exit page content in the condition" do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-      expect(response).to render_template(:show)
-      expect(assigns(:exit_page)).to have_attributes(
-        heading: exit_page_heading,
-        markdown: exit_page_markdown,
-      )
-    end
-  end
+      let(:step_without_exit_page) do
+        step = build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3)
+        step.attributes.delete(:exit_pages)
+        step
+      end
 
-  context "when the form document is using old-style exit pages" do
-    let(:exit_page_heading) { Faker::Lorem.sentence }
-    let(:exit_page_markdown) { Faker::Lorem.paragraph }
+      let(:step_with_exit_page) { step_without_exit_page }
 
-    let(:condition_with_exit_page) do
-      condition = build(:v2_condition, routing_page_id: 2, goto_page_id: nil, skip_to_end: nil, exit_page_id: nil, exit_page_heading:, exit_page_markdown:)
-      condition.attributes.delete(:exit_page_id)
-      condition
-    end
-
-    let(:step_without_exit_page) do
-      step = build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3)
-      step.attributes.delete(:exit_pages)
-      step
-    end
-
-    let(:step_with_exit_page) { step_without_exit_page }
-
-    it "falls back to the exit page content in the condition" do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-      expect(response).to render_template(:show)
-      expect(assigns(:exit_page)).to have_attributes(
-        heading: exit_page_heading,
-        markdown: exit_page_markdown,
-      )
+      it "falls back to the exit page content in the condition" do
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        expect(response).to render_template(:show)
+        expect(assigns(:exit_page)).to have_attributes(
+          heading: exit_page_heading,
+          markdown: exit_page_markdown,
+        )
+      end
     end
   end
 end

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -1061,7 +1061,30 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
       it "redirects to the exit page when exit page answer given" do
         post save_form_step_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id, params: { question: { selection: "Option 1" }, changing_existing_answer: false })
-        expect(response).to redirect_to exit_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id)
+        expect(response).to redirect_to exit_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id, exit_page_id: exit_page.id)
+      end
+
+      context "when form document uses old-style exit pages" do
+        let(:routing_condition) do
+          build(
+            :v2_condition,
+            routing_page_id: 1,
+            exit_page_heading: "Exit page heading",
+            exit_page_markdown: "Exit page markdown",
+          )
+        end
+        let(:first_step_in_form) do
+          build(:v2_selection_question_step,
+                id: 1,
+                next_step_id: 2,
+                is_optional: false,
+                routing_conditions: [routing_condition])
+        end
+
+        it "redirects to the exit page when exit page answer given" do
+          post save_form_step_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id, params: { question: { selection: "Option 1" }, changing_existing_answer: false })
+          expect(response).to redirect_to exit_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id)
+        end
       end
 
       it "redirects to the next step in the form when any other answer given" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/0ijhpyt8/3146-update-forms-runner-to-work-with-more-than-one-exit-page-for-a-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Add an optional exit page id to the exit page path, and use it for new-style exit pages.

This is mainly useful for analytics/debugging purposes, it lets us see just from the request path which exit pages are visited most frequently for a form.

There are various edge cases we try to handle: as for other steps, if the path doesn't match the page the form filler should be shown based on their answers, rather than showing an error page they are redirected to the correct path. Also, to try and avoid redirect loops or 404s when deploying this change, there is a temporary fallback for paths without the exit page id which can be reverted in a future PR.

For old-style exit pages we continue to use the path without the exit page id.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
