### PR TITLE
Handle steps with more than exit page

### DIFF
--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -6,12 +6,13 @@ module Forms
     end
 
     def show
-      unless current_context.can_visit?(@step.id) && @step.exit_page_condition_matches?
-        return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug)
-      end
+      return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug) unless current_context.can_visit?(@step.id)
+
+      @condition = @step.matching_condition
+
+      return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug) unless @condition&.exit_page?
 
       @back_link = form_step_path(@form.id, @form.form_slug, @step.id)
-      @condition = @step.routing_conditions.first
 
       if @condition.new_style_exit_page?
         unless @condition.exit_page_id == params[:exit_page_id]

--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -14,11 +14,6 @@ module Forms
       @condition = @step.routing_conditions.first
 
       if @condition.new_style_exit_page?
-        # TODO: Revert the following lines once they have been fully deployed to production.
-        # They're a fallback to handle a zero-downtime deploy but should not be needed otherwise.
-        params[:exit_page_id] = @condition.exit_page_id if params[:exit_page_id].nil?
-        CurrentRequestLoggingAttributes.exit_page_id = params[:exit_page_id]
-
         unless @condition.exit_page_id == params[:exit_page_id]
           return redirect_to exit_page_path(@form.id, @form.form_slug, @step.id, @condition.exit_page_id)
         end

--- a/app/controllers/forms/step_controller.rb
+++ b/app/controllers/forms/step_controller.rb
@@ -102,7 +102,7 @@ module Forms
       return redirect_to review_file_page, success: t("banner.success.file_uploaded") if @step.answered_file_question?
 
       if @step.exit_page_condition_matches?
-        @condition = @step.routing_conditions.first
+        @condition = @step.matching_condition
         return redirect_to exit_page_path(form_id: @form.id, form_slug: @form.form_slug, step_slug: @step.id, exit_page_id: @condition.exit_page_id)
       end
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -99,20 +99,26 @@ class Step
     next_step_slug.nil?
   end
 
-  def next_step_slug_after_routing
-    if exit_page_condition_matches?
-      return nil
-    end
-
+  def matching_condition
     if first_condition_default?
-      return goto_condition_step_slug(routing_conditions.first)
+      return routing_conditions.first
     end
 
-    if (matching_condition = find_matching_condition)
-      return goto_condition_step_slug(matching_condition)
-    end
+    find_matching_condition
+  end
 
-    next_step_slug
+  def next_step_slug_after_routing
+    condition = matching_condition
+
+    if condition.nil?
+      next_step_slug
+    elsif condition.exit_page?
+      nil
+    elsif condition.skip_to_end?
+      CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG
+    else
+      condition.goto_page_id
+    end
   end
 
   def repeatable?
@@ -124,13 +130,15 @@ class Step
   end
 
   def has_exit_page_condition?
-    return false if routing_conditions&.first.blank?
-
-    routing_conditions.first.exit_page?
+    routing_conditions.any?(&:exit_page?)
   end
 
   def exit_page_condition_matches?
-    first_condition_matches? && routing_conditions.first.exit_page?
+    condition = find_matching_condition
+
+    return false if condition.nil?
+
+    condition.exit_page?
   end
 
   def answered_file_question?
@@ -147,24 +155,10 @@ class Step
 
 private
 
-  def goto_condition_step_slug(condition)
-    if condition.skip_to_end?
-      CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG
-    else
-      condition.goto_page_id
-    end
-  end
-
   def find_matching_condition
     return unless question.respond_to?(:selection)
 
     routing_conditions.find { it.match? question.selection }
-  end
-
-  def first_condition_matches?
-    return unless question.respond_to?(:selection)
-
-    routing_conditions.any? && routing_conditions.first.match?(question.selection)
   end
 
   def first_condition_default?

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -374,43 +374,86 @@ RSpec.describe Step do
   end
 
   describe "#has_exit_page_condition?" do
-    it "returns false when no routing conditions" do
-      expect(step.has_exit_page_condition?).to be false
+    context "when first condition has an exit page" do
+      let(:exit_page) { build(:v2_exit_page) }
+      let(:routing_conditions) { [build(:v2_condition, :with_exit_page, exit_page:)] }
+      let(:form_document_step) { build(:v2_selection_question_step, :with_exit_page, routing_conditions:, exit_page:) }
+
+      it "returns true" do
+        expect(step.has_exit_page_condition?).to be true
+      end
     end
 
-    it "returns false when first routing condition is not exit page" do
-      form_document_step.routing_conditions = [build(:v2_condition, answer_value: "Yes", goto_page_id: third_step_id)]
-      expect(step.has_exit_page_condition?).to be false
+    context "when first condition does not have an exit page" do
+      let(:routing_conditions) { [build(:v2_condition)] }
+      let(:form_document_step) { build(:v2_selection_question_step, routing_conditions:) }
+
+      it "returns false" do
+        expect(step.has_exit_page_condition?).to be false
+      end
     end
 
-    it "returns false when first routing condition contains markdown exit_page_markdown" do
-      form_document_step.routing_conditions = [build(:v2_condition, exit_page_markdown: 12)]
-      expect(step.has_exit_page_condition?).to be false
-    end
+    context "when there are no routing conditions" do
+      let(:form_document_step) { build(:v2_selection_question_step, routing_conditions: []) }
 
-    it "returns true when first routing condition contains string markdown exit_page_markdown" do
-      form_document_step.routing_conditions = [build(:v2_condition, exit_page_markdown: "")]
-      expect(step.has_exit_page_condition?).to be true
+      it "returns false" do
+        expect(step.has_exit_page_condition?).to be false
+      end
     end
   end
 
   describe "#exit_page_condition_matches?" do
-    let(:selection) { "Yes" }
-    let(:question) { instance_double(Question::Selection, selection:) }
-    let(:routing_conditions) { [build(:v2_condition, answer_value: "Yes", exit_page_markdown: "string")] }
-    let(:form_document_step) { build(:v2_question_step, position: 1, routing_conditions:) }
+    context "when first condition has an exit page" do
+      let(:exit_page) { build(:v2_exit_page) }
+      let(:routing_conditions) { [build(:v2_condition, :with_exit_page, answer_value: "Yes", exit_page:)] }
+      let(:form_document_step) { build(:v2_selection_question_step, :with_exit_page, routing_conditions:, exit_page:) }
 
-    it "returns true when condition matches and condition is an exit page" do
-      expect(step.exit_page_condition_matches?).to be true
+      context "when condition matches" do
+        let(:selection) { "Yes" }
+        let(:question) { instance_double(Question::Selection, selection:) }
+
+        it "returns true" do
+          expect(step.exit_page_condition_matches?).to be true
+        end
+      end
+
+      context "when condition doesn't match" do
+        let(:selection) { "No" }
+        let(:question) { instance_double(Question::Selection, selection:) }
+
+        it "returns false" do
+          expect(step.exit_page_condition_matches?).to be false
+        end
+      end
     end
 
-    it "when condition matches but not an exit page it returns false" do
-      routing_conditions.first.exit_page_markdown = nil
-      expect(step.exit_page_condition_matches?).to be false
+    context "when first condition does not have an exit page" do
+      let(:routing_conditions) { [build(:v2_condition, answer_value: "Yes")] }
+      let(:form_document_step) { build(:v2_selection_question_step, routing_conditions:) }
+
+      context "when condition matches" do
+        let(:selection) { "Yes" }
+        let(:question) { instance_double(Question::Selection, selection:) }
+
+        it "returns false" do
+          expect(step.exit_page_condition_matches?).to be false
+        end
+      end
+
+      context "when condition doesn't match" do
+        let(:selection) { "No" }
+        let(:question) { instance_double(Question::Selection, selection:) }
+
+        it "returns false" do
+          expect(step.exit_page_condition_matches?).to be false
+        end
+      end
     end
 
-    context "when condition doesn't match" do
-      let(:selection) { "No" }
+    context "when there are no routing conditions" do
+      let(:form_document_step) { build(:v2_selection_question_step, routing_conditions: []) }
+      let(:question) { instance_double(Question::Selection, selection:) }
+      let(:selection) { "Yes" }
 
       it "returns false" do
         expect(step.exit_page_condition_matches?).to be false

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -207,12 +207,41 @@ RSpec.describe Step do
       end
     end
 
+    describe "exit page routing" do
+      context "with exit_page_id" do
+        let(:routing_conditions) do
+          [
+            build(:v2_condition, :with_exit_page, answer_value: "Yes"),
+          ]
+        end
+        let(:selection) { "Yes" }
+
+        it "returns nil" do
+          expect(step.next_step_slug_after_routing).to be_nil
+        end
+      end
+
+      context "with exit_page_id and goto_page_id" do
+        let(:routing_conditions) do
+          [
+            build(:v2_condition, :with_exit_page, answer_value: "Yes", goto_page_id: fourth_step_id),
+          ]
+        end
+        let(:selection) { "Yes" }
+
+        it "prioritizes exit_page_id over goto_page_id" do
+          expect(step.next_step_slug_after_routing).to be_nil
+        end
+      end
+    end
+
     context "with multiple conditions" do
       let(:routing_conditions) do
         [
           build(:v2_condition, answer_value: "No", goto_page_id: first_step_id),
           build(:v2_condition, answer_value: "Yes", goto_page_id: second_step_id),
           build(:v2_condition, answer_value: "Maybe", goto_page_id: third_step_id),
+          build(:v2_condition, :with_exit_page, answer_value: "Can't decide"),
         ]
       end
 
@@ -237,6 +266,14 @@ RSpec.describe Step do
 
         it "returns the next_step_slug" do
           expect(step.next_step_slug_after_routing).to eq(third_step_id)
+        end
+      end
+
+      context "and condition with exit page matches" do
+        let(:selection) { "Can't decide" }
+
+        it "returns nil" do
+          expect(step.next_step_slug_after_routing).to be_nil
         end
       end
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -109,6 +109,91 @@ RSpec.describe Step do
     end
   end
 
+  describe "#matching_condition" do
+    let(:form_document_step) { build(:v2_selection_question_step, routing_conditions:) }
+    let(:question) { instance_double(Question::Selection, selection:) }
+
+    context "without any routing conditions" do
+      let(:routing_conditions) { [] }
+      let(:selection) { "Option 1" }
+
+      it "returns nil" do
+        expect(step.matching_condition).to be_nil
+      end
+    end
+
+    context "with a default condition" do
+      let(:default_condition) { build(:v2_condition, :default) }
+      let(:routing_conditions) do
+        [
+          default_condition,
+        ]
+      end
+
+      let(:selection) { "Option 99" }
+
+      it "returns the default condition" do
+        expect(step.matching_condition).to eq Condition.new(form_document_condition: default_condition)
+      end
+    end
+
+    context "with routing conditions" do
+      let(:condition) { build(:v2_condition, answer_value: "Option 2") }
+      let(:skip_to_end_condition) { build(:v2_condition, :skip_to_end, answer_value: "Option 3") }
+      let(:condition_with_exit_page) { build(:v2_condition, :with_exit_page, answer_value: "Option 4") }
+      let(:none_of_the_above_condition) { build(:v2_condition, answer_value: Question::Selection::NONE_OF_THE_ABOVE_VALUE) }
+
+      let(:routing_conditions) do
+        [
+          condition,
+          skip_to_end_condition,
+          condition_with_exit_page,
+          none_of_the_above_condition,
+        ]
+      end
+
+      context "when no condition matches" do
+        let(:selection) { "Option 1" }
+
+        it "returns nil" do
+          expect(step.matching_condition).to be_nil
+        end
+      end
+
+      context "when a condition matches" do
+        let(:selection) { "Option 2" }
+
+        it "returns the matching condition" do
+          expect(step.matching_condition).to eq Condition.new(form_document_condition: condition)
+        end
+      end
+
+      context "when a skip to end condition matches" do
+        let(:selection) { "Option 3" }
+
+        it "returns the matching condition" do
+          expect(step.matching_condition).to eq Condition.new(form_document_condition: skip_to_end_condition)
+        end
+      end
+
+      context "when a condition with an exit page matches" do
+        let(:selection) { "Option 4" }
+
+        it "returns the matching condition" do
+          expect(step.matching_condition).to eq Condition.new(form_document_condition: condition_with_exit_page)
+        end
+      end
+
+      context "when a none of the above condition matches" do
+        let(:selection) { Question::Selection::NONE_OF_THE_ABOVE_VALUE }
+
+        it "returns the matching condition" do
+          expect(step.matching_condition).to eq Condition.new(form_document_condition: none_of_the_above_condition)
+        end
+      end
+    end
+  end
+
   describe "#next_step_slug_after_routing" do
     let(:default_next_step_id) { "11111111" } # dummy value to make the default next step ID obvious when it appears
     let(:selection) { "Yes" }
@@ -411,9 +496,9 @@ RSpec.describe Step do
   end
 
   describe "#has_exit_page_condition?" do
-    context "when first condition has an exit page" do
+    context "when a routing condition has an exit page" do
       let(:exit_page) { build(:v2_exit_page) }
-      let(:routing_conditions) { [build(:v2_condition, :with_exit_page, exit_page:)] }
+      let(:routing_conditions) { [build(:v2_condition), build(:v2_condition, :with_exit_page, exit_page:)] }
       let(:form_document_step) { build(:v2_selection_question_step, :with_exit_page, routing_conditions:, exit_page:) }
 
       it "returns true" do
@@ -421,8 +506,8 @@ RSpec.describe Step do
       end
     end
 
-    context "when first condition does not have an exit page" do
-      let(:routing_conditions) { [build(:v2_condition)] }
+    context "when no routing condition has an exit page" do
+      let(:routing_conditions) { [build(:v2_condition), build(:v2_condition)] }
       let(:form_document_step) { build(:v2_selection_question_step, routing_conditions:) }
 
       it "returns false" do
@@ -440,9 +525,9 @@ RSpec.describe Step do
   end
 
   describe "#exit_page_condition_matches?" do
-    context "when first condition has an exit page" do
+    context "when a routing condition has an exit page" do
       let(:exit_page) { build(:v2_exit_page) }
-      let(:routing_conditions) { [build(:v2_condition, :with_exit_page, answer_value: "Yes", exit_page:)] }
+      let(:routing_conditions) { [build(:v2_condition, answer_value: "No"), build(:v2_condition, :with_exit_page, answer_value: "Yes", exit_page:)] }
       let(:form_document_step) { build(:v2_selection_question_step, :with_exit_page, routing_conditions:, exit_page:) }
 
       context "when condition matches" do
@@ -464,8 +549,8 @@ RSpec.describe Step do
       end
     end
 
-    context "when first condition does not have an exit page" do
-      let(:routing_conditions) { [build(:v2_condition, answer_value: "Yes")] }
+    context "when no condition has an exit page" do
+      let(:routing_conditions) { [build(:v2_condition, answer_value: "No"), build(:v2_condition, answer_value: "Yes")] }
       let(:form_document_step) { build(:v2_selection_question_step, routing_conditions:) }
 
       context "when condition matches" do

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -2,20 +2,49 @@ require "rails_helper"
 
 RSpec.describe Forms::ExitPagesController, type: :request do
   let(:exit_page) { build(:v2_exit_page) }
-  let(:steps) { [first_step_in_form, step_with_exit_page, next_step_in_form] }
-  let(:first_step_in_form) { build(:v2_question_step, :with_text_settings, id: 1, next_step_id: 2) }
-  let(:step_with_exit_page) { build(:v2_selection_question_step, :with_exit_page, id: 2, next_step_id: 3, exit_page:) }
-  let(:next_step_in_form) { build(:v2_question_step, id: 3, next_step_id: nil) }
-  let(:form) { build(:v2_form_document, steps:, start_page: 1) }
+  let(:exit_pages) { [exit_page] }
+
+  let(:step_with_exit_pages) do
+    build(
+      :v2_selection_question_step,
+      id: 2,
+      next_step_id: 3,
+      selection_options: [
+        { name: "Option 1" },
+        { name: "Option 2" },
+        { name: "Skip to end" },
+      ],
+      routing_conditions: [
+        build(
+          :v2_condition,
+          :with_exit_page,
+          answer_value: "Option 1",
+          exit_page: exit_pages.first,
+        ),
+        build(
+          :v2_condition,
+          :skip_to_end,
+          answer_value: "Skip to end",
+        ),
+      ],
+      exit_pages:,
+    )
+  end
 
   let(:answer) { "Option 1" }
+
+  let(:steps) { [first_step_in_form, step, next_step_in_form] }
+  let(:first_step_in_form) { build(:v2_question_step, :with_text_settings, id: 1, next_step_id: 2) }
+  let(:step) { step_with_exit_pages }
+  let(:next_step_in_form) { build(:v2_question_step, id: 3, next_step_id: nil) }
+  let(:form) { build(:v2_form_document, steps:, start_page: 1) }
 
   let(:store) do
     {
       answers: {
         form.form_id.to_s => {
           first_step_in_form.id.to_s => { text: "first answer" },
-          step_with_exit_page.id.to_s => { selection: answer },
+          step.id.to_s => { selection: answer },
         },
       },
     }
@@ -33,33 +62,51 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
   describe "GET #show" do
     it "returns http success" do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
       expect(response).to have_http_status(:success)
     end
 
     it "renders an exit page" do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
       expect(response).to render_template(:show)
       expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
     end
 
     it "logs the exit page id", :capture_logging do
-      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+      get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
       expect(log_lines.last["exit_page_id"]).to eq exit_page.id.to_s
     end
 
-    context "when the question with an exit page has been answered and the exit page should not be shown" do
-      let(:answer) { "Option 2" }
+    context "when the question with an exit page has been answered" do
+      context "and the answer does not match a condition" do
+        let(:answer) { "Option 2" }
 
-      it "redirects to the next unanswered question" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
-        expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+        it "redirects to the next unanswered question" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
+          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+        end
+
+        context "when the request path does not include an exit page id" do
+          it "redirects to the next unanswered question" do
+            get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id)
+            expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+          end
+        end
       end
 
-      context "when the request path does not include an exit page id" do
-        it "redirects to the next unanswered question" do
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
+      context "and the answer matches a condition without an exit page" do
+        let(:answer) { "Skip to end" }
+
+        it "redirects to the next visitable page" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
+          expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG)
+        end
+
+        context "when the request path does not include an exit page id" do
+          it "redirects to the next visitable question" do
+            get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id)
+            expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG)
+          end
         end
       end
     end
@@ -68,13 +115,13 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       let(:store) { { answers: {} } }
 
       it "redirects to the start of the form" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
         expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: first_step_in_form.id)
       end
 
       context "when the request path does not include an exit page id" do
         it "redirects to the start of the form" do
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id)
           expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: first_step_in_form.id)
         end
       end
@@ -82,7 +129,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
     context "when the step does not have an exit page" do
       let(:step_without_exit_page) { build(:v2_selection_question_step, id: 2, next_step_id: 3) }
-      let(:step_with_exit_page) { step_without_exit_page }
+      let(:step) { step_without_exit_page }
 
       it "redirects to the next unanswered question" do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id, exit_page_id: exit_page.id)
@@ -99,22 +146,22 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
     context "when the request path does not include an exit page id" do
       it "redirects to the correct exit page path" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id)
+        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
       end
     end
 
     context "when the step does not have an exit page with the given id" do
       it "redirects to the correct exit page path" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 99_999)
-        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: 99_999)
+        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
       end
 
       context "when the question with an exit page has been answered and the exit page should not be shown" do
         let(:answer) { "Option 2" }
 
         it "redirects to the next unanswered question" do
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 99_999)
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: 99_999)
           expect(response).to redirect_to form_step_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: next_step_in_form.id)
         end
       end
@@ -123,7 +170,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
     context "when the exit page is missing from the form document" do
       let(:condition_with_exit_page) { build(:v2_condition, :with_exit_page, routing_page_id: 2, exit_page:) }
       let(:step_without_exit_page) { build(:v2_selection_question_step, routing_conditions: [condition_with_exit_page], id: 2, next_step_id: 3) }
-      let(:step_with_exit_page) { step_without_exit_page }
+      let(:step) { step_without_exit_page }
 
       it "raises an error" do
         expect {
@@ -146,7 +193,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
         step
       end
 
-      let(:step_with_exit_page) { step_without_exit_page }
+      let(:step) { step_without_exit_page }
 
       it "falls back to the exit page content in the condition" do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)
@@ -181,7 +228,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
         step
       end
 
-      let(:step_with_exit_page) { step_without_exit_page }
+      let(:step) { step_without_exit_page }
 
       it "falls back to the exit page content in the condition" do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -97,12 +97,10 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       end
     end
 
-    context "when the request path does not include an exit page id", :capture_logging do
-      it "falls back to the old behaviour and renders the exit page for the matching condition" do
+    context "when the request path does not include an exit page id" do
+      it "redirects to the correct exit page path" do
         get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
-        expect(response).to render_template(:show)
-        expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
-        expect(log_lines.last["exit_page_id"]).to eq exit_page.id.to_s
+        expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
       end
     end
 

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Forms::ExitPagesController, type: :request do
-  let(:exit_page) { build(:v2_exit_page) }
-  let(:exit_pages) { [exit_page] }
+  let(:exit_page) { exit_pages.first }
+  let(:exit_pages) { build_list(:v2_exit_page, 2) }
 
   let(:step_with_exit_pages) do
     build(
@@ -12,6 +12,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       selection_options: [
         { name: "Option 1" },
         { name: "Option 2" },
+        { name: "Go to exit page 2" },
         { name: "Skip to end" },
       ],
       routing_conditions: [
@@ -20,6 +21,12 @@ RSpec.describe Forms::ExitPagesController, type: :request do
           :with_exit_page,
           answer_value: "Option 1",
           exit_page: exit_pages.first,
+        ),
+        build(
+          :v2_condition,
+          :with_exit_page,
+          answer_value: "Go to exit page 2",
+          exit_page: exit_pages.second,
         ),
         build(
           :v2_condition,
@@ -78,6 +85,25 @@ RSpec.describe Forms::ExitPagesController, type: :request do
     end
 
     context "when the question with an exit page has been answered" do
+      context "and the answer matches a condition with an exit page which is not the first routing condition" do
+        let(:exit_page) { exit_pages.second }
+        let(:answer) { "Go to exit page 2" }
+
+        it "renders the exit page" do
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
+          expect(response).to have_http_status(:success)
+          expect(response).to render_template(:show)
+          expect(assigns(:exit_page)).to eq ExitPage.from_form_document(exit_page)
+        end
+
+        context "when the request path does not include an exit page id" do
+          it "redirects to the correct exit page path" do
+            get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id)
+            expect(response).to redirect_to exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_pages.id, exit_page_id: exit_page.id)
+          end
+        end
+      end
+
       context "and the answer does not match a condition" do
         let(:answer) { "Option 2" }
 

--- a/spec/requests/forms/exit_pages_controller_spec.rb
+++ b/spec/requests/forms/exit_pages_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
       it "raises an error" do
         expect {
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: exit_page.id)
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id, exit_page_id: exit_page.id)
         }.to raise_error(/Couldn't find ExitPage/)
       end
     end
@@ -149,7 +149,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       let(:step_with_exit_page) { step_without_exit_page }
 
       it "falls back to the exit page content in the condition" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)
         expect(response).to render_template(:show)
         expect(assigns(:exit_page)).to have_attributes(
           heading: exit_page_heading,
@@ -159,7 +159,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
       context "when the request path includes an exit page id" do
         it "returns http not found" do
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 1)
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id, exit_page_id: 1)
           expect(response).to have_http_status(:not_found)
         end
       end
@@ -184,7 +184,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
       let(:step_with_exit_page) { step_without_exit_page }
 
       it "falls back to the exit page content in the condition" do
-        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id)
+        get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id)
         expect(response).to render_template(:show)
         expect(assigns(:exit_page)).to have_attributes(
           heading: exit_page_heading,
@@ -194,7 +194,7 @@ RSpec.describe Forms::ExitPagesController, type: :request do
 
       context "when the request path includes an exit page id" do
         it "returns http not found" do
-          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_with_exit_page.id, exit_page_id: 1)
+          get exit_page_path(mode: "form", form_id: form.form_id, form_slug: form.form_slug, step_slug: step_without_exit_page.id, exit_page_id: 1)
           expect(response).to have_http_status(:not_found)
         end
       end

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -1064,6 +1064,46 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
         expect(response).to redirect_to exit_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id, exit_page_id: exit_page.id)
       end
 
+      context "when step has more than one exit page" do
+        let(:exit_pages) { build_list(:v2_exit_page, 2) }
+        let(:first_step_in_form) do
+          build(
+            :v2_selection_question_step,
+            :with_exit_page,
+            id: 1,
+            next_step_id: 2,
+            is_optional: false,
+            selection_options: [
+              { value: "Answer" },
+              { value: "Go to exit page 1" },
+              { value: "Go to exit page 2" },
+            ],
+            routing_conditions: [
+              build(
+                :v2_condition,
+                :with_exit_page,
+                routing_page_id: 1,
+                answer_value: "Go to exit page 1",
+                exit_page: exit_pages.first,
+              ),
+              build(
+                :v2_condition,
+                :with_exit_page,
+                routing_page_id: 1,
+                answer_value: "Go to exit page 2",
+                exit_page: exit_pages.second,
+              ),
+            ],
+            exit_pages:,
+          )
+        end
+
+        it "redirects to the correct exit page" do
+          post save_form_step_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id, params: { question: { selection: "Go to exit page 2" }, changing_existing_answer: false })
+          expect(response).to redirect_to exit_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id, exit_page_id: exit_pages.second.id)
+        end
+      end
+
       context "when form document uses old-style exit pages" do
         let(:routing_condition) do
           build(


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/0ijhpyt8/3146-update-forms-runner-to-work-with-more-than-one-exit-page-for-a-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Update forms-runner to work with steps with more than one exit page.

This is mostly tests, with some changes to the step model, and some small changes to the step controller and exit page controller.

The code to get the exit page id in the step controller is very inefficient, but I've already spent too long refactoring forms-runner to make this change work.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
