### PR TITLE
Fetch form branding from the brands API

### DIFF
--- a/.review_apps/ecs_task_definition.tf
+++ b/.review_apps/ecs_task_definition.tf
@@ -2,6 +2,10 @@ locals {
   logs_stream_prefix = "${data.terraform_remote_state.review.outputs.review_apps_log_group_name}/forms-runner/pr-${var.pull_request_number}"
   assets_bucket_name = try(data.terraform_remote_state.review.outputs.assets_bucket_name, "govuk-forms-review-assets")
 
+  # try() so that deploys succeed before the review environment state has
+  # published the assets outputs
+  forms_admin_task_role_arn = try(data.terraform_remote_state.review.outputs.forms_admin_task_role_arn, null)
+
   runner_review_app_hostname = "pr-${var.pull_request_number}.submit.review.forms.service.gov.uk"
 
   # Admin has it's own hostname because it needs to be user facing too,
@@ -68,6 +72,10 @@ resource "aws_ecs_task_definition" "task" {
   }
 
   execution_role_arn = data.terraform_remote_state.review.outputs.ecs_task_execution_role_arn
+
+  # Gives the forms-admin container permission to upload brand assets to the
+  # assets bucket
+  task_role_arn = local.forms_admin_task_role_arn
 
   container_definitions = jsonencode([
 

--- a/app/components/custom_branding_component/view.html.erb
+++ b/app/components/custom_branding_component/view.html.erb
@@ -1,6 +1,6 @@
 <style>
   :root:has(.app-custom-branding)  {
-    --custom-background-colour: <%= branding['background_colour'] %>;
-    --custom-border-colour: <%= branding['border_colour'] %>;
+    --custom-background-colour: <%= branding.background_colour %>;
+    --custom-border-colour: <%= branding.border_colour %>;
   }
 </style>

--- a/app/components/footer_component/view.rb
+++ b/app/components/footer_component/view.rb
@@ -34,7 +34,7 @@ module FooterComponent
     end
 
     def copyright_holder
-      @form.branding["copyright_holder"]
+      @form.branding.copyright_holder
     end
 
     def accessibility_statement

--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -18,9 +18,9 @@ module FormHeaderComponent
           safe_join([
             govuk_generic_header do |header|
               header.with_logo do
-                content_tag("a", href: branding["organisation_url"], class: "app-header__logo-link") do
-                  tag.img(src: branding["logo"],
-                          alt: branding["organisation_name"],
+                content_tag("a", href: branding.organisation_url, class: "app-header__logo-link") do
+                  tag.img(src: branding.logo,
+                          alt: branding.organisation_name,
                           class: "app-header__logo-image")
                 end
               end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,6 +82,7 @@ private
   def set_request_id
     if Rails.env.production?
       Api::V2::FormDocumentResource.headers["X-Request-ID"] = request.request_id
+      Api::V2::BrandResource.headers["X-Request-ID"] = request.request_id
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,11 +20,11 @@ module ApplicationHelper
   end
 
   def site_name(form:)
-    (form&.has_custom_branding? ? form.branding["organisation_name"] : "GOV.UK")
+    (form&.has_custom_branding? ? form.branding.organisation_name : "GOV.UK")
   end
 
   def theme_colour(form:)
-    (form&.has_custom_branding? ? form.branding["background_colour"] : "#1d70b8")
+    (form&.has_custom_branding? ? form.branding.background_colour : "#1d70b8")
   end
 
   def question_text_with_hidden_mode(question_text, mode)

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -8,6 +8,11 @@ class Brand
                   favicon
                   opengraph].freeze
 
+  CACHE_TTL = 5.minutes
+  # cached in place of the brand attributes so that 404s from the API are not
+  # repeated for every page load
+  NOT_FOUND = "not_found".freeze
+
   attr_reader(*ATTRIBUTES)
 
   def initialize(background_colour: nil, border_colour: nil, organisation_name: nil, organisation_url: nil,
@@ -22,15 +27,55 @@ class Brand
     @opengraph = opengraph
   end
 
-  def self.find(brand_id)
-    return nil if brand_id.blank?
+  class << self
+    def find(brand_id)
+      return nil if brand_id.blank?
 
-    attributes = BRANDING_CONFIG[brand_id]
-    from_attributes(attributes) if attributes
-  end
+      attributes = BRANDING_CONFIG[brand_id] || attributes_from_api(brand_id)
+      from_attributes(attributes) if attributes
+    end
 
-  # attributes is a string-keyed hash in the shape of an entry in config/branding.yml
-  def self.from_attributes(attributes)
-    new(**attributes.symbolize_keys.slice(*ATTRIBUTES))
+    # attributes is a string-keyed hash in the shape of an entry in config/branding.yml
+    def from_attributes(attributes)
+      new(**attributes.symbolize_keys.slice(*ATTRIBUTES))
+    end
+
+  private
+
+    def attributes_from_api(brand_id)
+      attributes = Rails.cache.fetch(cache_key(brand_id), expires_in: CACHE_TTL) do
+        fetch_brand(brand_id)
+      end
+
+      attributes == NOT_FOUND ? nil : attributes
+    rescue ActiveResource::ConnectionError, SocketError, SystemCallError => e
+      Rails.logger.warn("Failed to fetch brand from the API - #{e.class.name}: #{e.message}", { brand_id: })
+      nil
+    end
+
+    def fetch_brand(brand_id)
+      brand = Api::V2::BrandResource.find(brand_id)
+      api_attributes(brand.attributes)
+    rescue ActiveResource::ResourceNotFound
+      NOT_FOUND
+    end
+
+    def cache_key(brand_id)
+      "api/v2/brand/#{brand_id}"
+    end
+
+    # match the shape of the entries in config/branding.yml
+    def api_attributes(attributes)
+      {
+        "background_colour" => attributes["header_background_colour"],
+        "border_colour" => attributes["border_colour"],
+        "organisation_name" => attributes["name"],
+        "organisation_url" => attributes["logo_link"],
+        "copyright_holder" => attributes["copyright_holder"],
+        "logo" => attributes["logo_path"],
+        "favicon" => attributes["favicon_path"],
+        "opengraph" => attributes["opengraph_image_path"],
+      }
+    end
   end
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,0 +1,36 @@
+class Brand
+  ATTRIBUTES = %i[background_colour
+                  border_colour
+                  organisation_name
+                  organisation_url
+                  copyright_holder
+                  logo
+                  favicon
+                  opengraph].freeze
+
+  attr_reader(*ATTRIBUTES)
+
+  def initialize(background_colour: nil, border_colour: nil, organisation_name: nil, organisation_url: nil,
+                 copyright_holder: nil, logo: nil, favicon: nil, opengraph: nil)
+    @background_colour = background_colour
+    @border_colour = border_colour
+    @organisation_name = organisation_name
+    @organisation_url = organisation_url
+    @copyright_holder = copyright_holder
+    @logo = logo
+    @favicon = favicon
+    @opengraph = opengraph
+  end
+
+  def self.find(brand_id)
+    return nil if brand_id.blank?
+
+    attributes = BRANDING_CONFIG[brand_id]
+    from_attributes(attributes) if attributes
+  end
+
+  # attributes is a string-keyed hash in the shape of an entry in config/branding.yml
+  def self.from_attributes(attributes)
+    new(**attributes.symbolize_keys.slice(*ATTRIBUTES))
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -86,14 +86,12 @@ class Form
   end
 
   def has_custom_branding?
-    return false if form_document.try(:brand_id).blank?
-
-    BRANDING_CONFIG.key?(form_document.brand_id)
+    branding.present?
   end
 
   def branding
-    return nil unless has_custom_branding?
+    return nil if form_document.try(:brand_id).blank?
 
-    BRANDING_CONFIG[form_document.brand_id]
+    @branding ||= Brand.find(form_document.brand_id)
   end
 end

--- a/app/resources/api/v2/brand_resource.rb
+++ b/app/resources/api/v2/brand_resource.rb
@@ -1,0 +1,10 @@
+class Api::V2::BrandResource < ActiveResource::Base
+  self.element_name = "brand"
+  self.site = Settings.forms_api.base_url
+  self.prefix = "/api/v2/"
+  self.include_format_in_path = false
+
+  def self.find(brand_id)
+    super(:one, from: "/api/v2/brands/#{brand_id}")
+  end
+end

--- a/app/views/layouts/_custom_branding_email_banner.html.erb
+++ b/app/views/layouts/_custom_branding_email_banner.html.erb
@@ -6,8 +6,8 @@
           <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
             <tr>
               <td valign="middle" style="padding: 10px 0 10px 10px;">
-                <a href="<%= @branding['organisation_url'] %>" title="<%= @branding['organisation_name'] %>" style="text-decoration: none;">
-                  <img src="<%= branding_asset_url(@branding['logo']) %>" alt="<%= @branding['organisation_name'] %>" height="100" border="0" style="max-height: 100px; vertical-align: middle;">
+                <a href="<%= @branding.organisation_url %>" title="<%= @branding.organisation_name %>" style="text-decoration: none;">
+                  <img src="<%= branding_asset_url(@branding.logo) %>" alt="<%= @branding.organisation_name %>" height="100" border="0" style="max-height: 100px; vertical-align: middle;">
                 </a>
               </td>
             </tr>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -9,8 +9,8 @@
 
     <meta name="theme-color" content="<%= theme_colour(form: @current_context&.form) %>">
     <% if @current_context&.form&.has_custom_branding? %>
-      <link rel="icon" sizes="48x48" href="<%= @current_context.form.branding["favicon"] %>">
-      <meta property="og:image" content="<%= @current_context.form.branding["opengraph"] %>">
+      <link rel="icon" sizes="48x48" href="<%= @current_context.form.branding.favicon %>">
+      <meta property="og:image" content="<%= @current_context.form.branding.opengraph %>">
     <% else %>
       <link rel="icon" sizes="48x48" href="<%= vite_asset_path "#{govuk_assets_path}/images/favicon.ico" %>">
       <link rel="icon" sizes="any" href="<%= vite_asset_path "#{govuk_assets_path}/images/favicon.svg" %>" type="image/svg+xml">

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -47,7 +47,7 @@
     <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
       <tr>
 <% if @branding.present? %>
-        <td width="100%" bgcolor="<%= @branding['background_colour'] %>" class="brand__banner" style="border-bottom: 4px solid <%= @branding['border_colour'] %>;">
+        <td width="100%" bgcolor="<%= @branding.background_colour %>" class="brand__banner" style="border-bottom: 4px solid <%= @branding.border_colour %>;">
 <%= render "layouts/custom_branding_email_banner" %>
         </td>
 <% else %>

--- a/spec/components/custom_branding_component/custom_branding_component_preview.rb
+++ b/spec/components/custom_branding_component/custom_branding_component_preview.rb
@@ -17,13 +17,13 @@ class CustomBrandingComponent::CustomBrandingComponentPreview < ViewComponent::P
                           name: "test_form_name",
                           form_slug: "test",
                           has_custom_branding?: true,
-                          branding: {
-                            "background_colour" => "#ffffff",
-                            "border_colour" => "#206c49",
-                            "organisation_name" => "Cheshire East Council",
-                            "organisation_url" => "https://www.cheshireeast.gov.uk",
-                            "logo" => "/brand_assets/cheshire-east/logo.png",
-                          })
+                          branding: Brand.new(
+                            background_colour: "#ffffff",
+                            border_colour: "#206c49",
+                            organisation_name: "Cheshire East Council",
+                            organisation_url: "https://www.cheshireeast.gov.uk",
+                            logo: "/brand_assets/cheshire-east/logo.png",
+                          ))
 
     render(CustomBrandingComponent::View.new(form:))
   end

--- a/spec/components/custom_branding_component/view_spec.rb
+++ b/spec/components/custom_branding_component/view_spec.rb
@@ -34,13 +34,12 @@ RSpec.describe CustomBrandingComponent::View, type: :component do
                             name: "test_form_name",
                             form_slug: "test",
                             has_custom_branding?: true,
-                            branding: {
-                              "background_colour" => "#ffffff",
-                              "border_colour" => "#206c49",
-                              "organisation_name" => "Cheshire East Council",
-                              "organisation_url" => "https://www.cheshireeast.gov.uk",
-                              "logo" => "/brand_assets/cheshire-east/logo.png",
-                            })
+                            branding: build(:brand,
+                                            background_colour: "#ffffff",
+                                            border_colour: "#206c49",
+                                            organisation_name: "Cheshire East Council",
+                                            organisation_url: "https://www.cheshireeast.gov.uk",
+                                            logo: "/brand_assets/cheshire-east/logo.png"))
 
       render_inline(described_class.new(form: form))
     end

--- a/spec/components/footer_component/footer_component_preview.rb
+++ b/spec/components/footer_component/footer_component_preview.rb
@@ -15,9 +15,7 @@ class FooterComponent::FooterComponentPreview < ViewComponent::Preview
                           name: "test",
                           form_slug: "test",
                           has_custom_branding?: true,
-                          branding: {
-                            "copyright_holder" => "Cheshire East Council",
-                          })
+                          branding: Brand.new(copyright_holder: "Cheshire East Council"))
     render(FooterComponent::View.new(mode:, form:))
   end
 end

--- a/spec/components/footer_component/view_spec.rb
+++ b/spec/components/footer_component/view_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe FooterComponent::View, type: :component do
   let(:form) { build :v2_form_document, id: 1 }
   let(:mode) { Mode.new }
 
+  include_context "with branding from branding.yml"
+
   before do
     render_inline(described_class.new(mode: mode, form: form))
   end

--- a/spec/components/footer_component/view_spec.rb
+++ b/spec/components/footer_component/view_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe FooterComponent::View, type: :component do
       context "when the brand has no copyright holder" do
         let(:form) do
           build(:form, brand_id: "cheshire-east", id: 1).tap do |form|
-            allow(form).to receive(:branding).and_return({})
+            allow(form).to receive(:branding).and_return(build(:brand, copyright_holder: nil))
           end
         end
 

--- a/spec/components/form_header_component/form_header_component_preview.rb
+++ b/spec/components/form_header_component/form_header_component_preview.rb
@@ -28,13 +28,13 @@ class FormHeaderComponent::FormHeaderComponentPreview < ViewComponent::Preview
                           name: "test_form_name",
                           form_slug: "test",
                           has_custom_branding?: true,
-                          branding: {
-                            "background_colour" => "#ffffff",
-                            "border_colour" => "#206c49",
-                            "organisation_name" => "Cheshire East Council",
-                            "organisation_url" => "https://www.cheshireeast.gov.uk",
-                            "logo" => "/brand_assets/cheshire-east/logo.png",
-                          })
+                          branding: Brand.new(
+                            background_colour: "#ffffff",
+                            border_colour: "#206c49",
+                            organisation_name: "Cheshire East Council",
+                            organisation_url: "https://www.cheshireeast.gov.uk",
+                            logo: "/brand_assets/cheshire-east/logo.png",
+                          ))
 
     mode = Mode.new
     current_context = OpenStruct.new(form:)

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -134,13 +134,12 @@ RSpec.describe FormHeaderComponent::View, type: :component do
                      name: "test_form_name",
                      form_slug: "test",
                      has_custom_branding?: true,
-                     branding: {
-                       "background_colour" => "#ffffff",
-                       "border_colour" => "#206c49",
-                       "organisation_name" => "Cheshire East Council",
-                       "organisation_url" => "https://www.cheshireeast.gov.uk",
-                       "logo" => "/brand_assets/cheshire-east/logo.png",
-                     })
+                     branding: build(:brand,
+                                     background_colour: "#ffffff",
+                                     border_colour: "#206c49",
+                                     organisation_name: "Cheshire East Council",
+                                     organisation_url: "https://www.cheshireeast.gov.uk",
+                                     logo: "/brand_assets/cheshire-east/logo.png"))
     end
 
     it "renders the brand logo with the organisation name as alt text" do

--- a/spec/factories/models/brands.rb
+++ b/spec/factories/models/brands.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :brand, class: "Brand" do
+    initialize_with { new(**attributes) }
+
+    background_colour { "#ffffff" }
+    border_colour { "#00703c" }
+    organisation_name { "Weatherfield Borough Council" }
+    organisation_url { "https://www.weatherfield.example.com" }
+    copyright_holder { "Weatherfield Borough Council" }
+    logo { "/assets/brands/weatherfield/logo-abc123.png" }
+    favicon { "/assets/brands/weatherfield/favicon-abc123.ico" }
+    opengraph { "/assets/brands/weatherfield/opengraph-image-abc123.jpg" }
+
+    trait :without_assets do
+      logo { nil }
+      favicon { nil }
+      opengraph { nil }
+    end
+  end
+end

--- a/spec/factories/v2_brand.rb
+++ b/spec/factories/v2_brand.rb
@@ -1,0 +1,22 @@
+FactoryBot.define do
+  factory :v2_brand, class: Api::V2::BrandResource do
+    name { "Weatherfield Borough Council" }
+    slug { "weatherfield" }
+    header_background_colour { "#ffffff" }
+    border_colour { "#00703c" }
+    logo_alt_text { "Weatherfield Borough Council" }
+    logo_link { "https://www.weatherfield.example.com" }
+    copyright_holder { "Weatherfield Borough Council" }
+    logo_path { "/assets/brands/weatherfield/logo-abc123.png" }
+    favicon_path { "/assets/brands/weatherfield/favicon-abc123.ico" }
+    opengraph_image_path { "/assets/brands/weatherfield/opengraph-image-abc123.jpg" }
+
+    trait :without_assets do
+      logo_path { nil }
+      favicon_path { nil }
+      opengraph_image_path { nil }
+    end
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 describe FormSubmissionMailer, type: :mailer do
   subject(:mail) { described_class.submission_email(submission:, files:, csv_filename:, json_filename:) }
 
+  include_context "with branding from branding.yml"
+
   let(:submission) do
     build(:submission, form_document: form_document, created_at: submission_timestamp,
                        reference: submission_reference, is_preview:, submission_locale:)

--- a/spec/mailers/submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/submission_confirmation_mailer_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe SubmissionConfirmationMailer, type: :mailer do
     )
   end
 
+  include_context "with branding from branding.yml"
+
   let(:confirmation_email_address) { "testing@example.gov.uk" }
   let(:include_copy_of_answers) { true }
   let(:welsh_form) { Form.new(welsh_form_document) if welsh_form_document }

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Brand, type: :model do
+  describe ".find" do
+    context "when the brand ID is blank" do
+      it "returns nil" do
+        expect(described_class.find(nil)).to be_nil
+        expect(described_class.find("")).to be_nil
+      end
+    end
+
+    context "when the brand ID is not known" do
+      it "returns nil" do
+        expect(described_class.find("midsomer")).to be_nil
+      end
+    end
+
+    context "when the brand ID is in branding.yml" do
+      it "returns a brand with the attributes of the branding.yml entry" do
+        brand = described_class.find("cheshire-east")
+
+        expect(brand).to be_a(described_class)
+        expect(brand).to have_attributes(**BRANDING_CONFIG["cheshire-east"].symbolize_keys)
+      end
+
+      it "returns nil for attributes the branding.yml entry does not have" do
+        expect(described_class.find("south-gloucestershire")).to have_attributes(opengraph: nil)
+      end
+    end
+  end
+
+  describe ".from_attributes" do
+    it "builds a brand from a string-keyed hash" do
+      brand = described_class.from_attributes(
+        "background_colour" => "#ffffff",
+        "organisation_name" => "Weatherfield Borough Council",
+      )
+
+      expect(brand).to have_attributes(
+        background_colour: "#ffffff",
+        organisation_name: "Weatherfield Borough Council",
+        logo: nil,
+      )
+    end
+
+    it "ignores unknown keys" do
+      expect(described_class.from_attributes("unknown" => "value")).to be_a(described_class)
+    end
+  end
+end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,30 +1,148 @@
 require "rails_helper"
 
 RSpec.describe Brand, type: :model do
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(cache)
+  end
+
   describe ".find" do
     context "when the brand ID is blank" do
-      it "returns nil" do
+      before do
+        ActiveResource::HttpMock.respond_to({})
+      end
+
+      it "returns nil without calling the API" do
         expect(described_class.find(nil)).to be_nil
         expect(described_class.find("")).to be_nil
+        expect(ActiveResource::HttpMock.requests).to be_empty
       end
     end
 
-    context "when the brand ID is not known" do
-      it "returns nil" do
-        expect(described_class.find("midsomer")).to be_nil
+    context "when the brand is in branding.yml" do
+      before do
+        ActiveResource::HttpMock.respond_to({})
       end
-    end
 
-    context "when the brand ID is in branding.yml" do
-      it "returns a brand with the attributes of the branding.yml entry" do
+      it "returns a brand with the attributes of the branding.yml entry without calling the API" do
         brand = described_class.find("cheshire-east")
 
         expect(brand).to be_a(described_class)
         expect(brand).to have_attributes(**BRANDING_CONFIG["cheshire-east"].symbolize_keys)
+        expect(ActiveResource::HttpMock.requests).to be_empty
       end
 
       it "returns nil for attributes the branding.yml entry does not have" do
         expect(described_class.find("south-gloucestershire")).to have_attributes(opengraph: nil)
+      end
+    end
+
+    context "when the brand is not in branding.yml" do
+      context "and the API has the brand" do
+        let(:brand_resource) { build :v2_brand }
+
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v2/brands/weatherfield", req_headers, brand_resource.to_json, 200
+          end
+        end
+
+        it "returns a brand with the attributes from the API" do
+          expect(described_class.find("weatherfield")).to have_attributes(
+            background_colour: "#ffffff",
+            border_colour: "#00703c",
+            organisation_name: "Weatherfield Borough Council",
+            organisation_url: "https://www.weatherfield.example.com",
+            copyright_holder: "Weatherfield Borough Council",
+            logo: "/assets/brands/weatherfield/logo-abc123.png",
+            favicon: "/assets/brands/weatherfield/favicon-abc123.ico",
+            opengraph: "/assets/brands/weatherfield/opengraph-image-abc123.jpg",
+          )
+        end
+
+        it "caches the response so repeated calls make a single API request" do
+          2.times { described_class.find("weatherfield") }
+
+          expect(ActiveResource::HttpMock.requests.count).to eq 1
+        end
+
+        it "caches the branding attributes as a plain hash" do
+          described_class.find("weatherfield")
+
+          expect(cache.read("api/v2/brand/weatherfield")).to be_a Hash
+        end
+
+        it "returns a brand when served from the cache" do
+          described_class.find("weatherfield")
+
+          expect(described_class.find("weatherfield")).to be_a described_class
+        end
+
+        context "when the brand has no assets uploaded" do
+          let(:brand_resource) { build :v2_brand, :without_assets }
+
+          it "returns nil asset paths" do
+            expect(described_class.find("weatherfield")).to have_attributes(
+              logo: nil,
+              favicon: nil,
+              opengraph: nil,
+            )
+          end
+        end
+      end
+
+      context "and the API does not have the brand" do
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v2/brands/midsomer", req_headers, nil, 404
+          end
+        end
+
+        it "returns nil" do
+          expect(described_class.find("midsomer")).to be_nil
+        end
+
+        it "caches the not found response so repeated calls make a single API request" do
+          2.times { described_class.find("midsomer") }
+
+          expect(ActiveResource::HttpMock.requests.count).to eq 1
+        end
+      end
+
+      context "and the API returns a server error" do
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v2/brands/midsomer", req_headers, nil, 500
+          end
+        end
+
+        it "logs a warning and returns nil" do
+          expect(Rails.logger).to receive(:warn).with(/Failed to fetch brand from the API/, { brand_id: "midsomer" })
+
+          expect(described_class.find("midsomer")).to be_nil
+        end
+
+        it "does not cache the error, so the next call tries the API again" do
+          allow(Rails.logger).to receive(:warn)
+
+          2.times { described_class.find("midsomer") }
+
+          expect(ActiveResource::HttpMock.requests.count).to eq 2
+        end
+      end
+
+      context "and the API cannot be reached" do
+        before do
+          allow(Api::V2::BrandResource).to receive(:find).and_raise(ActiveResource::TimeoutError.new("execution expired"))
+        end
+
+        it "logs a warning and returns nil" do
+          expect(Rails.logger).to receive(:warn).with(/Failed to fetch brand from the API/, { brand_id: "midsomer" })
+
+          expect(described_class.find("midsomer")).to be_nil
+        end
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -230,6 +230,11 @@ RSpec.describe Form, type: :model do
       it "returns false" do
         expect(form.has_custom_branding?).to be false
       end
+
+      it "does not look up the brand" do
+        expect(Brand).not_to receive(:find)
+        form.has_custom_branding?
+      end
     end
 
     context "when the form document has an empty brand ID" do
@@ -240,16 +245,24 @@ RSpec.describe Form, type: :model do
       end
     end
 
-    context "when the form document has a brand ID which is not configured" do
+    context "when the form document has a brand ID which is not known" do
       let(:form_document) { build :v2_form_document, :with_brand_id, brand_id: "midsomer" }
+
+      before do
+        allow(Brand).to receive(:find).with("midsomer").and_return(nil)
+      end
 
       it "returns false" do
         expect(form.has_custom_branding?).to be false
       end
     end
 
-    context "when the form document has a brand ID which is configured" do
+    context "when the form document has a brand ID which is known" do
       let(:form_document) { build :v2_form_document, brand_id: "cheshire-east" }
+
+      before do
+        allow(Brand).to receive(:find).with("cheshire-east").and_return(build(:brand))
+      end
 
       it "returns true" do
         expect(form.has_custom_branding?).to be true
@@ -274,19 +287,34 @@ RSpec.describe Form, type: :model do
       end
     end
 
-    context "when the form document has a brand ID which is not configured" do
+    context "when the form document has a brand ID which is not known" do
       let(:form_document) { build :v2_form_document, :with_brand_id, brand_id: "midsomer" }
+
+      before do
+        allow(Brand).to receive(:find).with("midsomer").and_return(nil)
+      end
 
       it "returns nil" do
         expect(form.branding).to be_nil
       end
     end
 
-    context "when the form document has a brand ID which is configured" do
-      let(:form_document) { build :v2_form_document, brand_id: "cheshire-east" }
+    context "when the form document has a brand ID which is known" do
+      let(:brand) { build :brand }
+      let(:form_document) { build :v2_form_document, brand_id: "weatherfield" }
 
-      it "returns the configured brand information" do
-        expect(form.branding).to eq BRANDING_CONFIG["cheshire-east"]
+      before do
+        allow(Brand).to receive(:find).with("weatherfield").and_return(brand)
+      end
+
+      it "returns the brand" do
+        expect(form.branding).to eq brand
+      end
+
+      it "memoises the brand lookup" do
+        2.times { form.branding }
+
+        expect(Brand).to have_received(:find).once
       end
     end
   end

--- a/spec/requests/forms/branded_accessibility_statement_controller_spec.rb
+++ b/spec/requests/forms/branded_accessibility_statement_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Forms::BrandedAccessibilityStatementController, type: :request do
+  include_context "with branding from branding.yml"
+
   let(:form_data) do
     build(:v2_form_document, :with_support,
           id: 2,

--- a/spec/resources/api/v2/brand_resource_spec.rb
+++ b/spec/resources/api/v2/brand_resource_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::BrandResource do
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:brand) { build :v2_brand }
+  let(:brand_id) { "weatherfield" }
+
+  describe ".find" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v2/brands/#{brand_id}", req_headers, brand.to_json, 200
+      end
+    end
+
+    it "finds a brand for a given brand ID" do
+      brand = described_class.find(brand_id)
+      expect(brand).to be_a(described_class)
+    end
+
+    it "returns the brand attributes" do
+      brand = described_class.find(brand_id)
+      expect(brand).to have_attributes(
+        name: "Weatherfield Borough Council",
+        header_background_colour: "#ffffff",
+        border_colour: "#00703c",
+        logo_link: "https://www.weatherfield.example.com",
+        copyright_holder: "Weatherfield Borough Council",
+        logo_path: "/assets/brands/weatherfield/logo-abc123.png",
+        favicon_path: "/assets/brands/weatherfield/favicon-abc123.ico",
+        opengraph_image_path: "/assets/brands/weatherfield/opengraph-image-abc123.jpg",
+      )
+    end
+  end
+end

--- a/spec/support/shared_context/branding.rb
+++ b/spec/support/shared_context/branding.rb
@@ -1,0 +1,5 @@
+RSpec.shared_context "with branding from branding.yml" do
+  before do
+    allow(Brand).to receive(:find) { |brand_id| Brand.from_attributes(BRANDING_CONFIG[brand_id]) if BRANDING_CONFIG[brand_id] }
+  end
+end

--- a/spec/views/branded_accessibility_statement/show.html.erb_spec.rb
+++ b/spec/views/branded_accessibility_statement/show.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "forms/branded_accessibility_statement/show.html.erb" do
+  include_context "with branding from branding.yml"
+
   let(:form) { build :form, brand_id: "cheshire-east" }
   let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
 


### PR DESCRIPTION
Forms with a brand_id now get their branding from the forms-admin brands API. 

This PR keeps the `config/branding.yml` as a priority source of config. But if a brand isn't present in the config yaml, it will try the API.

We cache brands for 5 minutes, so we don't have to request the brand for every page load.

Removing the yml once brands and their assets are fully setup from forms-admin.
