### PR TITLE
Remove delivery configurations fallback code

### DIFF
--- a/app/lib/batch_submissions_selector.rb
+++ b/app/lib/batch_submissions_selector.rb
@@ -1,15 +1,11 @@
 class BatchSubmissionsSelector
   Batch = Data.define(:form_id, :mode, :submissions)
 
-  # TODO: we can remove checking the send_daily_submission_batch and send_weekly_submission_batch in September 2026
-  # when all Submissions without delivery_configurations on the form document have been deleted.
   DAILY_BATCH_FORM_DOCUMENT_CONDITION = <<~SQL.squish
-    (form_document->>'send_daily_submission_batch')::boolean = true
-    OR form_document->'delivery_configurations' @> '[{"delivery_schedule":"daily"}]'::jsonb
+    form_document->'delivery_configurations' @> '[{"delivery_schedule":"daily"}]'::jsonb
   SQL
   WEEKLY_BATCH_FORM_DOCUMENT_CONDITION = <<~SQL.squish
-    (form_document->>'send_weekly_submission_batch')::boolean = true
-    OR form_document->'delivery_configurations' @> '[{"delivery_schedule":"weekly"}]'::jsonb
+    form_document->'delivery_configurations' @> '[{"delivery_schedule":"weekly"}]'::jsonb
   SQL
 
   class << self
@@ -20,7 +16,7 @@ class BatchSubmissionsSelector
 
           # If the most recent submission is configured for daily batching, include all submissions on that day in the
           # batch. If it is not, do not return a batch for any of the submissions on that day.
-          next unless submissions.any? && batch_enabled_for_daily_submission?(submissions.first.form_document)
+          next unless submissions.any? && daily_delivery_configuration?(submissions.first.form_document)
 
           yielder << Batch.new(form_id, mode, submissions)
         end
@@ -34,7 +30,7 @@ class BatchSubmissionsSelector
 
           # If the most recent submission is configured for weekly batching, include all submissions in that week in
           # the batch. If it is not, do not return a batch for any of the submissions in that week.
-          next unless submissions.any? && batch_enabled_for_weekly_submission?(submissions.first.form_document)
+          next unless submissions.any? && weekly_delivery_configuration?(submissions.first.form_document)
 
           yielder << Batch.new(form_id, mode, submissions)
         end
@@ -57,16 +53,6 @@ class BatchSubmissionsSelector
                 .where(WEEKLY_BATCH_FORM_DOCUMENT_CONDITION)
                 .distinct
                 .pluck(:form_id, :mode)
-    end
-
-    def batch_enabled_for_daily_submission?(form_document)
-      form_document["send_daily_submission_batch"] == true ||
-        daily_delivery_configuration?(form_document)
-    end
-
-    def batch_enabled_for_weekly_submission?(form_document)
-      form_document["send_weekly_submission_batch"] == true ||
-        weekly_delivery_configuration?(form_document)
     end
 
     def daily_delivery_configuration?(form_document)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,8 +15,6 @@ class Form
            :s3_bucket_name,
            :s3_bucket_region,
            :start_page,
-           :send_daily_submission_batch,
-           :send_weekly_submission_batch,
            :submission_email,
            :support_email,
            :support_phone,
@@ -36,12 +34,6 @@ class Form
     return nil if form_document.payment_url.blank?
 
     "#{form_document.payment_url}?reference=#{reference}"
-  end
-
-  # Deprecated: kept for historic Submission records. Use delivery_configurations on form_document.
-  # Can be removed in September 2026 when historic Submissions with this field have been deleted.
-  def submission_format
-    form_document.try(:submission_format) || []
   end
 
   def support_details

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -16,13 +16,8 @@ class S3SubmissionService
     # file arrives and the referenced files will already be present
     copy_uploaded_files_to_bucket
 
-    # This handles deliveries that were created before we started storing the formats on the delivery. This fallback and
-    # the deprecated `Form.submission_format` attribute can be removed from September 2026 when any failed deliveries
-    # will have been removed.
-    formats = @delivery.formats || @form.submission_format
-
     submission_content, key =
-      case formats
+      case @delivery.formats
       when %w[csv]
         [generate_csv_submission, generate_key("form_submission.csv")]
       when %w[json]

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -26,10 +26,7 @@ private
   def deliver_submission_email
     files = uploaded_files_in_answers
 
-    # This handles deliveries that were created before we started storing the formats on the delivery. This fallback and
-    # the deprecated `Form.submission_format` attribute can be removed from September 2026 when any failed deliveries
-    # will have been removed.
-    formats = @delivery.formats || @form.submission_format
+    formats = @delivery.formats
 
     csv_filename = nil
     if formats.include? "json"

--- a/spec/factories/v2_form_document.rb
+++ b/spec/factories/v2_form_document.rb
@@ -23,8 +23,6 @@ FactoryBot.define do
     s3_bucket_region { nil }
     updated_at { Time.current.iso8601(3) }
     send_copy_of_answers { "disabled" }
-    send_daily_submission_batch { false }
-    send_weekly_submission_batch { false }
     delivery_configurations { [build(:v2_delivery_configuration, :immediate_email)] }
 
     trait :with_steps do

--- a/spec/lib/batch_submissions_selector_spec.rb
+++ b/spec/lib/batch_submissions_selector_spec.rb
@@ -8,239 +8,123 @@ RSpec.describe BatchSubmissionsSelector do
 
     let(:date) { Time.zone.local(2022, 12, 1) }
 
-    context "when the form document does not have delivery_configurations (Backwards compatibility)" do
-      let(:form_document_with_batch_enabled) { build(:v2_form_document, send_daily_submission_batch: true) }
-      let(:form_document_with_batch_disabled) { build(:v2_form_document, send_daily_submission_batch: false) }
+    let(:form_document_with_batch_enabled) do
+      build(:v2_form_document, delivery_configurations: [
+        build(:v2_delivery_configuration, :daily_email),
+      ])
+    end
+    let(:form_document_with_batch_disabled) do
+      build(:v2_form_document, delivery_configurations: [
+        build(:v2_delivery_configuration, :immediate_email),
+      ])
+    end
 
-      context "when send_daily_submission_batch is enabled for the form document" do
-        context "when the date is during BST" do
-          let(:date) { Time.zone.local(2022, 6, 1) }
+    context "when the form document has a daily delivery_configuration" do
+      context "when the date is during BST" do
+        let(:date) { Time.zone.local(2022, 6, 1) }
 
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 5, 31, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2022, 6, 1, 22, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the BST day
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2022, 5, 31, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2022, 6, 1, 23, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the BST day to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2022, 5, 31, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2022, 6, 1, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions on the date" do
-            expect(daily_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions on the day in the batches" do
-            expect(daily_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(daily_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
+        let!(:form_submission) do
+          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 5, 31, 23, 0, 0), form_document: form_document_with_batch_enabled)
+        end
+        let!(:preview_draft_submission) do
+          create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2022, 6, 1, 22, 59, 59), form_document: form_document_with_batch_enabled)
         end
 
-        context "when the date is not in BST" do
-          let(:date) { Time.zone.local(2022, 12, 1) }
+        before do
+          # create form/mode combinations that only have submissions outside the BST day
+          create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2022, 5, 31, 22, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2022, 6, 1, 23, 0, 0), form_document: form_document_with_batch_enabled)
 
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 12, 1, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2022, 12, 1, 23, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the day
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2022, 11, 30, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2022, 12, 2, 0, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the day to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2022, 11, 30, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2022, 12, 2, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions on the date" do
-            expect(daily_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions on the day in the batches" do
-            expect(daily_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(daily_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
-        end
-      end
-
-      context "when send_daily_submission_batch is enabled part-way through the day for the form document" do
-        let!(:latest_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_enabled)
-        end
-        let!(:earlier_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED2", created_at: Time.utc(2022, 12, 1, 9, 0, 0), form_document: form_document_with_batch_disabled)
+          # create submissions for the form/mode included in a batch outside the BST day to ensure they are excluded
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2022, 5, 31, 22, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2022, 6, 1, 23, 0, 0), form_document: form_document_with_batch_enabled)
         end
 
-        it "includes a batch for the form and mode" do
+        it "includes only forms/modes with submissions on the date" do
           expect(daily_batches.map(&:to_h)).to contain_exactly(
             a_hash_including(form_id: form_id, mode: "form"),
+            a_hash_including(form_id: form_id, mode: "preview-draft"),
           )
         end
 
-        it "includes all the submissions in the batch" do
-          submissions = daily_batches.first.submissions
-          expect(submissions.pluck(:reference)).to contain_exactly(latest_submission.reference, earlier_submission.reference)
+        it "includes only submissions on the day in the batches" do
+          expect(daily_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
+          expect(daily_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
         end
       end
 
-      context "when send_daily_submission_batch is disabled for the form document" do
+      context "when the date is not in BST" do
+        let(:date) { Time.zone.local(2022, 12, 1) }
+
+        let!(:form_submission) do
+          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 12, 1, 0, 0, 0), form_document: form_document_with_batch_enabled)
+        end
+        let!(:preview_draft_submission) do
+          create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2022, 12, 1, 23, 59, 59), form_document: form_document_with_batch_enabled)
+        end
+
         before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_disabled)
+          # create form/mode combinations that only have submissions outside the day
+          create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2022, 11, 30, 23, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2022, 12, 2, 0, 0, 0), form_document: form_document_with_batch_enabled)
+
+          # create submissions for the form/mode included in a batch outside the day to ensure they are excluded
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2022, 11, 30, 23, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2022, 12, 2, 0, 0, 0), form_document: form_document_with_batch_enabled)
         end
 
-        it "does not include a batch for the form and mode" do
-          expect(daily_batches.to_a).to be_empty
-        end
-      end
-
-      context "when send_daily_submission_batch is disabled part-way through the day for the form document" do
-        before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_disabled)
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 9, 0, 0), form_document: form_document_with_batch_enabled)
+        it "includes only forms/modes with submissions on the date" do
+          expect(daily_batches.map(&:to_h)).to contain_exactly(
+            a_hash_including(form_id: form_id, mode: "form"),
+            a_hash_including(form_id: form_id, mode: "preview-draft"),
+          )
         end
 
-        it "does not include a batch for the form and mode" do
-          expect(daily_batches.to_a).to be_empty
+        it "includes only submissions on the day in the batches" do
+          expect(daily_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
+          expect(daily_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
         end
       end
     end
 
-    context "when the form document has delivery_configurations" do
-      let(:form_document_with_batch_enabled) do
-        build(:v2_form_document, send_daily_submission_batch: false, delivery_configurations: [
-          build(:v2_delivery_configuration, :daily_email),
-        ])
+    context "when a daily delivery_configuration is added part-way through the day for the form document" do
+      let!(:latest_submission) do
+        create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_enabled)
       end
-      let(:form_document_with_batch_disabled) do
-        build(:v2_form_document, send_daily_submission_batch: false, delivery_configurations: [
-          build(:v2_delivery_configuration, :immediate_email),
-        ])
+      let!(:earlier_submission) do
+        create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED2", created_at: Time.utc(2022, 12, 1, 9, 0, 0), form_document: form_document_with_batch_disabled)
       end
 
-      context "when the form document has a daily delivery_configuration" do
-        context "when the date is during BST" do
-          let(:date) { Time.zone.local(2022, 6, 1) }
-
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 5, 31, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2022, 6, 1, 22, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the BST day
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2022, 5, 31, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2022, 6, 1, 23, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the BST day to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2022, 5, 31, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2022, 6, 1, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions on the date" do
-            expect(daily_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions on the day in the batches" do
-            expect(daily_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(daily_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
-        end
-
-        context "when the date is not in BST" do
-          let(:date) { Time.zone.local(2022, 12, 1) }
-
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 12, 1, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2022, 12, 1, 23, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the day
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2022, 11, 30, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2022, 12, 2, 0, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the day to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2022, 11, 30, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2022, 12, 2, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions on the date" do
-            expect(daily_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions on the day in the batches" do
-            expect(daily_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(daily_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
-        end
+      it "includes a batch for the form and mode" do
+        expect(daily_batches.map(&:to_h)).to contain_exactly(
+          a_hash_including(form_id: form_id, mode: "form"),
+        )
       end
 
-      context "when a daily delivery_configuration is added part-way through the day for the form document" do
-        let!(:latest_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_enabled)
-        end
-        let!(:earlier_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED2", created_at: Time.utc(2022, 12, 1, 9, 0, 0), form_document: form_document_with_batch_disabled)
-        end
+      it "includes all the submissions in the batch" do
+        submissions = daily_batches.first.submissions
+        expect(submissions.pluck(:reference)).to contain_exactly(latest_submission.reference, earlier_submission.reference)
+      end
+    end
 
-        it "includes a batch for the form and mode" do
-          expect(daily_batches.map(&:to_h)).to contain_exactly(
-            a_hash_including(form_id: form_id, mode: "form"),
-          )
-        end
-
-        it "includes all the submissions in the batch" do
-          submissions = daily_batches.first.submissions
-          expect(submissions.pluck(:reference)).to contain_exactly(latest_submission.reference, earlier_submission.reference)
-        end
+    context "when a daily delivery_configuration does not exist for the form document" do
+      before do
+        create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_disabled)
       end
 
-      context "when a daily delivery_configuration does not exist for the form document" do
-        before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_disabled)
-        end
+      it "does not include a batch for the form and mode" do
+        expect(daily_batches.to_a).to be_empty
+      end
+    end
 
-        it "does not include a batch for the form and mode" do
-          expect(daily_batches.to_a).to be_empty
-        end
+    context "when a daily delivery_configuration is removed part-way through the day for the form document" do
+      before do
+        create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_disabled)
+        create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 9, 0, 0), form_document: form_document_with_batch_enabled)
       end
 
-      context "when a daily delivery_configuration is removed part-way through the day for the form document" do
-        before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 10, 0, 0), form_document: form_document_with_batch_disabled)
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2022, 12, 1, 9, 0, 0), form_document: form_document_with_batch_enabled)
-        end
-
-        it "does not include a batch for the form and mode" do
-          expect(daily_batches.to_a).to be_empty
-        end
+      it "does not include a batch for the form and mode" do
+        expect(daily_batches.to_a).to be_empty
       end
     end
   end
@@ -250,251 +134,129 @@ RSpec.describe BatchSubmissionsSelector do
 
     let(:date) { Time.zone.local(2025, 5, 19) }
 
-    context "when the form document does not have delivery_configurations (Backwards compatibility)" do
-      let(:form_document_with_batch_enabled) { build(:v2_form_document, send_weekly_submission_batch: true) }
-      let(:form_document_with_batch_disabled) { build(:v2_form_document, send_weekly_submission_batch: false) }
+    let(:form_document_with_batch_enabled) do
+      build(:v2_form_document, delivery_configurations: [
+        build(:v2_delivery_configuration, :weekly_email),
+      ])
+    end
+    let(:form_document_with_batch_disabled) do
+      build(:v2_form_document, delivery_configurations: [
+        build(:v2_delivery_configuration, :immediate_email),
+      ])
+    end
 
-      context "when send_weekly_submission_batch is enabled for the form document" do
-        context "when the week is during BST" do
-          let(:date) { Time.zone.local(2025, 5, 19) }
+    context "when the form document has a weekly delivery_configuration" do
+      context "when the week is during BST" do
+        let(:date) { Time.zone.local(2025, 5, 19) }
 
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 5, 18, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2025, 5, 25, 22, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the BST week
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2025, 5, 18, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2025, 5, 25, 23, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the BST week to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2025, 5, 18, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2025, 5, 25, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions in the week" do
-            expect(weekly_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions in the week in the batches" do
-            expect(weekly_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(weekly_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
+        let!(:form_submission) do
+          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 5, 18, 23, 0, 0), form_document: form_document_with_batch_enabled)
+        end
+        let!(:preview_draft_submission) do
+          create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2025, 5, 25, 22, 59, 59), form_document: form_document_with_batch_enabled)
         end
 
-        context "when the week is not in BST" do
-          let(:date) { Time.zone.local(2025, 11, 3) }
+        before do
+          # create form/mode combinations that only have submissions outside the BST week
+          create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2025, 5, 18, 22, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2025, 5, 25, 23, 0, 0), form_document: form_document_with_batch_enabled)
 
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 11, 3, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2025, 11, 9, 23, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the week
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2025, 11, 2, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2025, 11, 10, 0, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the week to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2025, 11, 2, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2025, 11, 10, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions in the week" do
-            expect(weekly_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions in the week in the batches" do
-            expect(weekly_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(weekly_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
-        end
-      end
-
-      context "when send_weekly_submission_batch is enabled part-way through the week for the form document" do
-        let(:date) { Time.zone.local(2025, 11, 3) }
-
-        let!(:latest_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 11, 5, 0, 0, 0), form_document: form_document_with_batch_enabled)
-        end
-        let!(:earlier_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED2", created_at: Time.utc(2025, 11, 4, 0, 0, 0), form_document: form_document_with_batch_disabled)
+          # create submissions for the form/mode included in a batch outside the BST week to ensure they are excluded
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2025, 5, 18, 22, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2025, 5, 25, 23, 0, 0), form_document: form_document_with_batch_enabled)
         end
 
-        it "includes a batch for the form and mode" do
+        it "includes only forms/modes with submissions in the week" do
           expect(weekly_batches.map(&:to_h)).to contain_exactly(
             a_hash_including(form_id: form_id, mode: "form"),
+            a_hash_including(form_id: form_id, mode: "preview-draft"),
           )
         end
 
-        it "includes all the submissions in the batch" do
-          submissions = weekly_batches.first.submissions
-          expect(submissions.pluck(:reference)).to contain_exactly(latest_submission.reference, earlier_submission.reference)
+        it "includes only submissions in the week in the batches" do
+          expect(weekly_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
+          expect(weekly_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
         end
       end
 
-      context "when send_weekly_submission_batch is disabled for the form document" do
+      context "when the week is not in BST" do
         let(:date) { Time.zone.local(2025, 11, 3) }
 
-        before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 5, 10, 0, 0), form_document: form_document_with_batch_disabled)
+        let!(:form_submission) do
+          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 11, 3, 0, 0, 0), form_document: form_document_with_batch_enabled)
         end
-
-        it "does not include a batch for the form and mode" do
-          expect(weekly_batches.to_a).to be_empty
+        let!(:preview_draft_submission) do
+          create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2025, 11, 9, 23, 59, 59), form_document: form_document_with_batch_enabled)
         end
-      end
-
-      context "when send_weekly_submission_batch is disabled part-way through the week for the form document" do
-        let(:date) { Time.zone.local(2025, 11, 3) }
 
         before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 5, 0, 0, 0), form_document: form_document_with_batch_disabled)
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 4, 0, 0, 0), form_document: form_document_with_batch_enabled)
+          # create form/mode combinations that only have submissions outside the week
+          create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2025, 11, 2, 23, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2025, 11, 10, 0, 0, 0), form_document: form_document_with_batch_enabled)
+
+          # create submissions for the form/mode included in a batch outside the week to ensure they are excluded
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2025, 11, 2, 23, 59, 59), form_document: form_document_with_batch_enabled)
+          create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2025, 11, 10, 0, 0, 0), form_document: form_document_with_batch_enabled)
         end
 
-        it "does not include a batch for the form and mode" do
-          expect(weekly_batches.to_a).to be_empty
+        it "includes only forms/modes with submissions in the week" do
+          expect(weekly_batches.map(&:to_h)).to contain_exactly(
+            a_hash_including(form_id: form_id, mode: "form"),
+            a_hash_including(form_id: form_id, mode: "preview-draft"),
+          )
+        end
+
+        it "includes only submissions in the week in the batches" do
+          expect(weekly_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
+          expect(weekly_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
         end
       end
     end
 
-    context "when the form document has delivery_configurations" do
-      let(:form_document_with_batch_enabled) do
-        build(:v2_form_document, send_weekly_submission_batch: false, delivery_configurations: [
-          build(:v2_delivery_configuration, :weekly_email),
-        ])
+    context "when a weekly delivery_configuration is added part-way through the day for the form document" do
+      let(:date) { Time.zone.local(2025, 11, 3) }
+
+      let!(:latest_submission) do
+        create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 11, 5, 0, 0, 0), form_document: form_document_with_batch_enabled)
       end
-      let(:form_document_with_batch_disabled) do
-        build(:v2_form_document, send_weekly_submission_batch: false, delivery_configurations: [
-          build(:v2_delivery_configuration, :immediate_email),
-        ])
+      let!(:earlier_submission) do
+        create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED2", created_at: Time.utc(2025, 11, 4, 0, 0, 0), form_document: form_document_with_batch_disabled)
       end
 
-      context "when the form document has a weekly delivery_configuration" do
-        context "when the week is during BST" do
-          let(:date) { Time.zone.local(2025, 5, 19) }
-
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 5, 18, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2025, 5, 25, 22, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the BST week
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2025, 5, 18, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2025, 5, 25, 23, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the BST week to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2025, 5, 18, 22, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2025, 5, 25, 23, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions in the week" do
-            expect(weekly_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions in the week in the batches" do
-            expect(weekly_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(weekly_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
-        end
-
-        context "when the week is not in BST" do
-          let(:date) { Time.zone.local(2025, 11, 3) }
-
-          let!(:form_submission) do
-            create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 11, 3, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-          let!(:preview_draft_submission) do
-            create(:submission, form_id: form_id, mode: "preview-draft", reference: "INCLUDED2", created_at: Time.utc(2025, 11, 9, 23, 59, 59), form_document: form_document_with_batch_enabled)
-          end
-
-          before do
-            # create form/mode combinations that only have submissions outside the week
-            create(:submission, form_id: form_id, mode: "preview-archived", reference: "OMITTED1", created_at: Time.utc(2025, 11, 2, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: 102, mode: "form", reference: "OMITTED2", created_at: Time.utc(2025, 11, 10, 0, 0, 0), form_document: form_document_with_batch_enabled)
-
-            # create submissions for the form/mode included in a batch outside the week to ensure they are excluded
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED3", created_at: Time.utc(2025, 11, 2, 23, 59, 59), form_document: form_document_with_batch_enabled)
-            create(:submission, form_id: form_id, mode: "form", reference: "OMITTED4", created_at: Time.utc(2025, 11, 10, 0, 0, 0), form_document: form_document_with_batch_enabled)
-          end
-
-          it "includes only forms/modes with submissions in the week" do
-            expect(weekly_batches.map(&:to_h)).to contain_exactly(
-              a_hash_including(form_id: form_id, mode: "form"),
-              a_hash_including(form_id: form_id, mode: "preview-draft"),
-            )
-          end
-
-          it "includes only submissions in the week in the batches" do
-            expect(weekly_batches.to_a[0].submissions.pluck(:reference)).to contain_exactly(form_submission.reference)
-            expect(weekly_batches.to_a[1].submissions.pluck(:reference)).to contain_exactly(preview_draft_submission.reference)
-          end
-        end
+      it "includes a batch for the form and mode" do
+        expect(weekly_batches.map(&:to_h)).to contain_exactly(
+          a_hash_including(form_id: form_id, mode: "form"),
+        )
       end
 
-      context "when a weekly delivery_configuration is added part-way through the day for the form document" do
-        let(:date) { Time.zone.local(2025, 11, 3) }
+      it "includes all the submissions in the batch" do
+        submissions = weekly_batches.first.submissions
+        expect(submissions.pluck(:reference)).to contain_exactly(latest_submission.reference, earlier_submission.reference)
+      end
+    end
 
-        let!(:latest_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED1", created_at: Time.utc(2025, 11, 5, 0, 0, 0), form_document: form_document_with_batch_enabled)
-        end
-        let!(:earlier_submission) do
-          create(:submission, form_id: form_id, mode: "form", reference: "INCLUDED2", created_at: Time.utc(2025, 11, 4, 0, 0, 0), form_document: form_document_with_batch_disabled)
-        end
+    context "when a weekly delivery_configuration does not exist for the form document" do
+      let(:date) { Time.zone.local(2025, 11, 3) }
 
-        it "includes a batch for the form and mode" do
-          expect(weekly_batches.map(&:to_h)).to contain_exactly(
-            a_hash_including(form_id: form_id, mode: "form"),
-          )
-        end
-
-        it "includes all the submissions in the batch" do
-          submissions = weekly_batches.first.submissions
-          expect(submissions.pluck(:reference)).to contain_exactly(latest_submission.reference, earlier_submission.reference)
-        end
+      before do
+        create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 5, 10, 0, 0), form_document: form_document_with_batch_disabled)
       end
 
-      context "when a weekly delivery_configuration does not exist for the form document" do
-        let(:date) { Time.zone.local(2025, 11, 3) }
+      it "does not include a batch for the form and mode" do
+        expect(weekly_batches.to_a).to be_empty
+      end
+    end
 
-        before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 5, 10, 0, 0), form_document: form_document_with_batch_disabled)
-        end
+    context "when a weekly delivery_configuration is removed part-way through the week for the form document" do
+      let(:date) { Time.zone.local(2025, 11, 3) }
 
-        it "does not include a batch for the form and mode" do
-          expect(weekly_batches.to_a).to be_empty
-        end
+      before do
+        create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 5, 0, 0, 0), form_document: form_document_with_batch_disabled)
+        create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 4, 0, 0, 0), form_document: form_document_with_batch_enabled)
       end
 
-      context "when a weekly delivery_configuration is removed part-way through the week for the form document" do
-        let(:date) { Time.zone.local(2025, 11, 3) }
-
-        before do
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 5, 0, 0, 0), form_document: form_document_with_batch_disabled)
-          create(:submission, form_id: form_id, mode: "form", created_at: Time.utc(2025, 11, 4, 0, 0, 0), form_document: form_document_with_batch_enabled)
-        end
-
-        it "does not include a batch for the form and mode" do
-          expect(weekly_batches.to_a).to be_empty
-        end
+      it "does not include a batch for the form and mode" do
+        expect(weekly_batches.to_a).to be_empty
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -33,26 +33,6 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "#submission_format" do
-    let(:form_document) { build :v2_form_document, submission_format: }
-
-    context "when the submission format attribute is nil" do
-      let(:submission_format) { nil }
-
-      it "returns no submission delivery formats" do
-        expect(form.submission_format).to eq []
-      end
-    end
-
-    context "when the submission format attribute is an array of strings" do
-      let(:submission_format) { %w[csv json] }
-
-      it "returns the submission format attribute" do
-        expect(form.submission_format).to eq %w[csv json]
-      end
-    end
-  end
-
   describe "#support_details" do
     let(:form_document) do
       build :v2_form_document,

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -126,20 +126,6 @@ RSpec.describe S3SubmissionService do
         end
       end
 
-      context "when the formats are nil on the delivery" do
-        let(:delivery) { build :delivery, formats: nil }
-        let(:form_document) do
-          build(:v2_form_document, :s3_submissions_enabled, submission_format: %w[json])
-        end
-
-        it "falls back to using the submission_format on the form" do
-          expected_key_name = "form_submissions/#{form_document.form_id}/#{expected_timestamp}_#{submission_reference}/form_submission.json"
-          expect(mock_s3_client).to receive(:put_object).with(hash_including(key: expected_key_name))
-
-          service.submit
-        end
-      end
-
       context "when the form has answered file upload questions" do
         let(:first_file_upload_question) { build(:file, :with_uploaded_file, original_filename: "file.txt") }
         let(:second_file_upload_question) { build(:file, :with_uploaded_file, original_filename: "file.txt", filename_suffix: "_1") }

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -252,25 +252,6 @@ RSpec.describe SubmissionService do
       end
     end
 
-    context "when the formats are nil on the delivery" do
-      let(:delivery) { build :delivery, formats: nil }
-      let(:form_document) { build(:v2_form_document, name: "A great form", submission_email:, submission_format: %w[csv]) }
-
-      it "falls back to using the submission_format on the form" do
-        allow(FormSubmissionMailer).to receive(:submission_email).and_call_original
-
-        service.submit
-        expected_csv_content = "Reference,Submitted at,What is the meaning of life?\n#{submission_reference},2022-12-14T08:00:00+00:00,42\n"
-
-        expect(FormSubmissionMailer).to have_received(:submission_email).with(
-          submission: submission,
-          files: { "govuk_forms_a_great_form_#{submission_reference}.csv" => expected_csv_content },
-          csv_filename: "govuk_forms_a_great_form_#{submission_reference}.csv",
-          json_filename: nil,
-        ).once
-      end
-    end
-
     context "when form being submitted is from previewed form" do
       let(:is_preview) { true }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->Related to https://trello.com/c/P7bDQZTP/3248-get-submission-delivery-configuration-from-latest-live-version-of-the-form-in-forms-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
When we implemented delivery configurations, we added fallback methods to handle any submissions that predated this work. We've now waited long enough that any submissions without delivery configurations have been processed and deleted, so we can remove this fallback code.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
