### PR TITLE
Support fetching form documents from v3 API

### DIFF
--- a/app/resources/api/v3/form_document_resource.rb
+++ b/app/resources/api/v3/form_document_resource.rb
@@ -9,11 +9,20 @@ class Api::V3::FormDocumentResource < ActiveResource::Base
 
   class << self
     def find_by_tag(form_id, tag, **options)
-      get("#{form_id}/versions/#{tag}", **options)
+      return draft_form_document(form_id, **options) if tag == :draft
+
+      latest_version = get("#{form_id}/versions/#{tag}", **options)["version"]
+      find_by_version(form_id, latest_version, **options)
     end
 
     def find_by_version(form_id, version, **options)
       get("#{form_id}/versions/#{version}", **options)
+    end
+
+  private
+
+    def draft_form_document(form_id, **options)
+      get("#{form_id}/versions/draft", **options)
     end
   end
 end

--- a/app/resources/api/v3/form_document_resource.rb
+++ b/app/resources/api/v3/form_document_resource.rb
@@ -1,0 +1,15 @@
+class Api::V3::FormDocumentResource < ActiveResource::Base
+  self.element_name = "form"
+  self.site = Settings.forms_api.base_url
+  self.prefix = "/api/v3/"
+  self.include_format_in_path = false
+
+  has_many :steps, class_name: "Api::V2::StepResource"
+  has_many :delivery_configurations, class_name: "Api::V2::DeliveryConfigurationResource"
+
+  class << self
+    def find_by_tag(form_id, tag, **options)
+      get("#{form_id}/versions/#{tag}", **options)
+    end
+  end
+end

--- a/app/resources/api/v3/form_document_resource.rb
+++ b/app/resources/api/v3/form_document_resource.rb
@@ -11,5 +11,9 @@ class Api::V3::FormDocumentResource < ActiveResource::Base
     def find_by_tag(form_id, tag, **options)
       get("#{form_id}/versions/#{tag}", **options)
     end
+
+    def find_by_version(form_id, version, **options)
+      get("#{form_id}/versions/#{version}", **options)
+    end
   end
 end

--- a/app/services/api/v3/form_document_repository.rb
+++ b/app/services/api/v3/form_document_repository.rb
@@ -1,0 +1,27 @@
+class Api::V3::FormDocumentRepository
+  class << self
+    def find_by_tag(form_id:, tag:, language: :en)
+      return nil unless form_id.to_s =~ /^[[:alnum:]]+$/
+
+      begin
+        form_document_json = Api::V3::FormDocumentResource.find_by_tag(form_id, tag, **options_for_language(language))
+        Api::V3::FormDocumentResource.new(form_document_json)
+      rescue ActiveResource::ResourceNotFound
+        nil
+      end
+    end
+
+    def find_with_mode(form_id:, mode:, language: :en)
+      find_by_tag(form_id:, tag: mode.tag, language:)
+    end
+
+  private
+
+    # Don't include English in the options hash as it's the default
+    def options_for_language(language)
+      return {} if language.blank? || language.to_sym == :en
+
+      { language: language.to_sym }
+    end
+  end
+end

--- a/app/services/api/v3/form_document_repository.rb
+++ b/app/services/api/v3/form_document_repository.rb
@@ -11,6 +11,18 @@ class Api::V3::FormDocumentRepository
       end
     end
 
+    def find_by_version(form_id:, version:, language: :en)
+      return nil unless form_id.to_s =~ /^[[:alnum:]]+$/
+      return nil unless version.to_s =~ /^[0-9]+$/
+
+      begin
+        form_document_json = Api::V3::FormDocumentResource.find_by_version(form_id, version, **options_for_language(language))
+        Api::V3::FormDocumentResource.new(form_document_json)
+      rescue ActiveResource::ResourceNotFound
+        nil
+      end
+    end
+
     def find_with_mode(form_id:, mode:, language: :en)
       find_by_tag(form_id:, tag: mode.tag, language:)
     end

--- a/spec/resources/api/v3/form_document_resource_spec.rb
+++ b/spec/resources/api/v3/form_document_resource_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::FormDocumentResource do
+  let(:response_data) { File.read("spec/fixtures/all_question_types_form.json") }
+
+  let(:req_headers) { { "Accept" => "application/json" } }
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v3/forms/1/versions/live", req_headers, response_data, 200
+    end
+  end
+
+  describe ".find_by_tag" do
+    it "gets a form document given a form id and document tag" do
+      expect(described_class.find_by_tag(1, :live)).to be_truthy
+    end
+
+    it "returns a hash" do
+      form_document = described_class.find_by_tag(1, :live)
+      expect(form_document).to be_a Hash
+      expect(form_document["steps"]).to all be_a Hash
+    end
+
+    it "raises an exception if the form does not exist" do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/99/versions/draft", req_headers, nil, 404
+      end
+
+      expect {
+        described_class.find_by_tag("99", :draft)
+      }.to raise_error(ActiveResource::ResourceNotFound)
+    end
+
+    context "when tag is live" do
+      let(:response_data) { { id: 1, name: "form name", steps: [] } }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v3/forms/1/versions/live", req_headers, response_data.to_json, 200
+        end
+      end
+
+      it "returns a live form" do
+        form = described_class.find_by_tag(1, :live)
+
+        expect(form).to include("id" => 1, "name" => "form name")
+
+        expect(ActiveResource::HttpMock.requests)
+          .to include ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/live", nil, req_headers)
+      end
+    end
+
+    context "when tag is draft" do
+      let(:response_data) { { id: 1, name: "form name", steps: [] } }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v3/forms/1/versions/draft", req_headers, response_data.to_json, 200
+        end
+      end
+
+      it "returns a draft form" do
+        form = described_class.find_by_tag(1, :draft)
+
+        expect(form).to include("id" => 1, "name" => "form name")
+
+        expect(ActiveResource::HttpMock.requests)
+          .to include ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/draft", nil, req_headers)
+      end
+    end
+
+    context "when mode is archived" do
+      let(:response_data) { { id: 1, name: "form name", steps: [] } }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v3/forms/1/versions/archived", req_headers, response_data.to_json, 200
+        end
+      end
+
+      it "returns an archived form" do
+        form = described_class.find_by_tag(1, :archived)
+
+        expect(form).to include("id" => 1, "name" => "form name")
+
+        expect(ActiveResource::HttpMock.requests)
+          .to include ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/archived", nil, req_headers)
+      end
+    end
+
+    context "when given options" do
+      let(:request_with_param) { ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/live?another=1&param=value") }
+
+      before do
+        mock_response = ActiveResource::Response.new("{}")
+        ActiveResource::HttpMock.respond_to(request_with_param => mock_response)
+      end
+
+      it "adds params to the request" do
+        described_class.find_by_tag(1, :live, param: :value, another: 1)
+        expect(ActiveResource::HttpMock.requests).to include request_with_param
+      end
+    end
+  end
+
+  describe "#as_json" do
+    it "returns a hash of the form document's attributes as read from the API" do
+      form_document = described_class.find_by_tag(1, :live)
+      expect(form_document.as_json).to eq JSON.parse(response_data)
+    end
+  end
+end

--- a/spec/resources/api/v3/form_document_resource_spec.rb
+++ b/spec/resources/api/v3/form_document_resource_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Api::V3::FormDocumentResource do
   describe ".find_by_tag" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v3/forms/1/versions/live", req_headers, response_data, 200
+        mock.get "/api/v3/forms/1/versions/live", req_headers, { version: 2 }.to_json, 200
+        mock.get "/api/v3/forms/1/versions/2", req_headers, response_data, 200
       end
     end
 
@@ -37,7 +38,8 @@ RSpec.describe Api::V3::FormDocumentResource do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v3/forms/1/versions/live", req_headers, response_data.to_json, 200
+          mock.get "/api/v3/forms/1/versions/live", req_headers, { version: 2 }.to_json, 200
+          mock.get "/api/v3/forms/1/versions/2", req_headers, response_data.to_json, 200
         end
       end
 
@@ -75,7 +77,8 @@ RSpec.describe Api::V3::FormDocumentResource do
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v3/forms/1/versions/archived", req_headers, response_data.to_json, 200
+          mock.get "/api/v3/forms/1/versions/archived", req_headers, { version: 2 }.to_json, 200
+          mock.get "/api/v3/forms/1/versions/2", req_headers, response_data.to_json, 200
         end
       end
 
@@ -90,16 +93,19 @@ RSpec.describe Api::V3::FormDocumentResource do
     end
 
     context "when given options" do
-      let(:request_with_param) { ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/live?another=1&param=value") }
+      let(:request_tag_with_param) { ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/live?another=1&param=value") }
+      let(:request_version_with_param) { ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/2?another=1&param=value") }
 
       before do
         mock_response = ActiveResource::Response.new("{}")
-        ActiveResource::HttpMock.respond_to(request_with_param => mock_response)
+        ActiveResource::HttpMock.respond_to(request_tag_with_param => ActiveResource::Response.new({ version: 2 }.to_json),
+                                            request_version_with_param => mock_response)
       end
 
       it "adds params to the request" do
         described_class.find_by_tag(1, :live, param: :value, another: 1)
-        expect(ActiveResource::HttpMock.requests).to include request_with_param
+        expect(ActiveResource::HttpMock.requests).to include request_tag_with_param
+        expect(ActiveResource::HttpMock.requests).to include request_version_with_param
       end
     end
   end
@@ -159,7 +165,8 @@ RSpec.describe Api::V3::FormDocumentResource do
   describe "#as_json" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v3/forms/1/versions/live", req_headers, response_data, 200
+        mock.get "/api/v3/forms/1/versions/live", req_headers, { version: 2 }.to_json, 200
+        mock.get "/api/v3/forms/1/versions/2", req_headers, response_data, 200
       end
     end
 

--- a/spec/resources/api/v3/form_document_resource_spec.rb
+++ b/spec/resources/api/v3/form_document_resource_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Api::V3::FormDocumentResource do
 
   let(:req_headers) { { "Accept" => "application/json" } }
 
-  before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v3/forms/1/versions/live", req_headers, response_data, 200
-    end
-  end
-
   describe ".find_by_tag" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/1/versions/live", req_headers, response_data, 200
+      end
+    end
+
     it "gets a form document given a form id and document tag" do
       expect(described_class.find_by_tag(1, :live)).to be_truthy
     end
@@ -104,7 +104,65 @@ RSpec.describe Api::V3::FormDocumentResource do
     end
   end
 
+  describe ".find_by_version" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/1/versions/3", req_headers, response_data, 200
+      end
+    end
+
+    it "gets a form document given a form id and version number" do
+      expect(described_class.find_by_version(1, 3)).to be_truthy
+    end
+
+    it "returns a hash" do
+      form_document = described_class.find_by_version(1, 3)
+      expect(form_document).to be_a Hash
+      expect(form_document["steps"]).to all be_a Hash
+    end
+
+    it "raises an exception if the form does not exist" do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/99/versions/3", req_headers, nil, 404
+      end
+
+      expect {
+        described_class.find_by_version(99, 3)
+      }.to raise_error(ActiveResource::ResourceNotFound)
+    end
+
+    it "raises an exception if the version does not exist" do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/1/versions/5", req_headers, nil, 404
+      end
+
+      expect {
+        described_class.find_by_version(1, 5)
+      }.to raise_error(ActiveResource::ResourceNotFound)
+    end
+
+    context "when given options" do
+      let(:request_with_param) { ActiveResource::Request.new(:get, "/api/v3/forms/1/versions/3?another=1&param=value") }
+
+      before do
+        mock_response = ActiveResource::Response.new("{}")
+        ActiveResource::HttpMock.respond_to(request_with_param => mock_response)
+      end
+
+      it "adds params to the request" do
+        described_class.find_by_version(1, 3, param: :value, another: 1)
+        expect(ActiveResource::HttpMock.requests).to include request_with_param
+      end
+    end
+  end
+
   describe "#as_json" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/1/versions/live", req_headers, response_data, 200
+      end
+    end
+
     it "returns a hash of the form document's attributes as read from the API" do
       form_document = described_class.find_by_tag(1, :live)
       expect(form_document.as_json).to eq JSON.parse(response_data)

--- a/spec/services/api/v3/form_document_repository_spec.rb
+++ b/spec/services/api/v3/form_document_repository_spec.rb
@@ -10,16 +10,12 @@ RSpec.describe Api::V3::FormDocumentRepository do
   describe ".find_by_tag" do
     let(:form_id) { "1" }
     let(:tag) { :live }
-    let(:response_data) { api_v3_response_data.to_json }
-    let(:welsh_response_data) { api_v3_welsh_response_data.to_json }
-    let(:status) { 200 }
+    let(:response_data) { api_v3_response_data }
+    let(:welsh_response_data) { api_v3_welsh_response_data }
     let(:language) { nil }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v3/forms/#{form_id}/versions/#{tag}", req_headers, response_data, status
-        mock.get "/api/v3/forms/#{form_id}/versions/#{tag}?language=cy", req_headers, welsh_response_data, status
-      end
+      allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with("1", :live).and_return(response_data)
     end
 
     it "returns form document" do
@@ -32,19 +28,14 @@ RSpec.describe Api::V3::FormDocumentRepository do
       let(:tag) { :archived }
 
       context "when form has been archived" do
+        before do
+          allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with("1", :archived).and_return(response_data)
+        end
+
         it "returns an archived form document" do
           form = described_class.find_by_tag(tag: :archived, form_id: form_id)
 
           expect(form).to have_attributes(form_id: form_id, name: "All question types form")
-        end
-      end
-
-      context "when a form has not been archived" do
-        let(:response_data) { nil }
-        let(:status) { 404 }
-
-        it "returns nil" do
-          expect(described_class.find_by_tag(tag: :archived, form_id: form_id)).to be_nil
         end
       end
     end
@@ -65,34 +56,38 @@ RSpec.describe Api::V3::FormDocumentRepository do
       end
     end
 
-    context "when the form does not exist" do
-      let(:form_id) { "99" }
-      let(:response_data) { nil }
-      let(:status) { 404 }
+    context "when the form document is not found" do
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with("1", :live).and_raise(ActiveResource::ResourceNotFound.new(nil))
+      end
 
       it "returns nil" do
         expect(described_class.find_by_tag(tag:, form_id:)).to be_nil
       end
     end
 
-    context "when given language makes correct request" do
-      let(:request_with_no_language_param) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{tag}", req_headers) }
-      let(:request_with_language_param_cy) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{tag}?language=cy", req_headers) }
-
+    context "when called with a language param" do
       before do
-        mock_response = ActiveResource::Response.new(response_data)
-        ActiveResource::HttpMock.respond_to(request_with_no_language_param => mock_response,
-                                            request_with_language_param_cy => mock_response)
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(form_id, tag).and_return(response_data)
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(form_id, tag, language: :cy).and_return(welsh_response_data)
       end
 
-      it "given :en makes request without the language param" do
-        described_class.find_by_tag(tag:, form_id:, language: :en)
-        expect(ActiveResource::HttpMock.requests).to include request_with_no_language_param
+      context "and the language is English" do
+        let(:language) { :en }
+
+        it "does not call the FormDocumentResource with the language param" do
+          described_class.find_by_tag(tag:, form_id:, language:)
+          expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(form_id, tag)
+        end
       end
 
-      it "given :cy makes request with the language param" do
-        described_class.find_by_tag(tag:, form_id:, language: :cy)
-        expect(ActiveResource::HttpMock.requests).to include request_with_language_param_cy
+      context "and the language is Welsh" do
+        let(:language) { :cy }
+
+        it "calls the FormDocumentResource with the language param" do
+          described_class.find_by_tag(tag:, form_id:, language:)
+          expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(form_id, tag, { language: })
+        end
       end
     end
   end
@@ -100,16 +95,12 @@ RSpec.describe Api::V3::FormDocumentRepository do
   describe ".find_by_version" do
     let(:form_id) { "1" }
     let(:version) { 3 }
-    let(:response_data) { api_v3_response_data.to_json }
-    let(:welsh_response_data) { api_v3_welsh_response_data.to_json }
-    let(:status) { 200 }
+    let(:response_data) { api_v3_response_data }
+    let(:welsh_response_data) { api_v3_welsh_response_data }
     let(:language) { nil }
 
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v3/forms/#{form_id}/versions/#{version}", req_headers, response_data, status
-        mock.get "/api/v3/forms/#{form_id}/versions/#{version}?language=cy", req_headers, welsh_response_data, status
-      end
+      allow(Api::V3::FormDocumentResource).to receive(:find_by_version).with("1", 3).and_return(response_data)
     end
 
     it "returns form document" do
@@ -142,59 +133,45 @@ RSpec.describe Api::V3::FormDocumentRepository do
       end
     end
 
-    context "when the form does not exist" do
-      let(:form_id) { "99" }
-      let(:response_data) { nil }
-      let(:status) { 404 }
-
-      it "returns nil" do
-        expect(described_class.find_by_version(version:, form_id:)).to be_nil
-      end
-    end
-
-    context "when the version does not exist" do
-      let(:version) { 5 }
-      let(:response_data) { nil }
-      let(:status) { 404 }
-
-      it "returns nil" do
-        expect(described_class.find_by_version(version:, form_id:)).to be_nil
-      end
-    end
-
-    context "when given language makes correct request" do
-      let(:request_with_no_language_param) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{version}", req_headers) }
-      let(:request_with_language_param_cy) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{version}?language=cy", req_headers) }
-
+    context "when the form document is not found" do
       before do
-        mock_response = ActiveResource::Response.new(response_data)
-        ActiveResource::HttpMock.respond_to(request_with_no_language_param => mock_response,
-                                            request_with_language_param_cy => mock_response)
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_version).with(form_id, version).and_raise(ActiveResource::ResourceNotFound.new(nil))
       end
 
-      it "given :en makes request without the language param" do
-        described_class.find_by_version(version:, form_id:, language: :en)
-        expect(ActiveResource::HttpMock.requests).to include request_with_no_language_param
+      it "returns nil" do
+        expect(described_class.find_by_version(version:, form_id:)).to be_nil
+      end
+    end
+
+    context "when called with a language param" do
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_version).with(form_id, version).and_return(response_data)
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_version).with(form_id, version, language: :cy).and_return(welsh_response_data)
       end
 
-      it "given :cy makes request with the language param" do
-        described_class.find_by_version(version:, form_id:, language: :cy)
-        expect(ActiveResource::HttpMock.requests).to include request_with_language_param_cy
+      context "and the language is English" do
+        let(:language) { :en }
+
+        it "does not call the FormDocumentResource with the language param" do
+          described_class.find_by_version(version:, form_id:, language:)
+          expect(Api::V3::FormDocumentResource).to have_received(:find_by_version).with(form_id, version)
+        end
+      end
+
+      context "and the language is Welsh" do
+        let(:language) { :cy }
+
+        it "calls the FormDocumentResource with the language param" do
+          described_class.find_by_version(version:, form_id:, language:)
+          expect(Api::V3::FormDocumentResource).to have_received(:find_by_version).with(form_id, version, language:)
+        end
       end
     end
   end
 
   describe ".find_with_mode" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v3/forms/1/versions/draft", req_headers, api_v3_response_data.merge(name: "Draft form").to_json, 200
-        mock.get "/api/v3/forms/1/versions/live", req_headers, api_v3_response_data.merge(name: "Live form").to_json, 200
-        mock.get "/api/v3/forms/1/versions/archived", req_headers, api_v3_response_data.merge(name: "Archived form").to_json, 200
-        mock.get "/api/v3/forms/2/versions/live", req_headers, nil, 404
-        mock.get "/api/v3/forms/2/versions/archived", req_headers, api_v3_response_data.to_json, 200
-        mock.get "/api/v3/forms/Alpha123/versions/draft", req_headers, api_v3_response_data.merge("form_id": "Alpha123").to_json, 200
-        mock.get "/api/v3/forms/99/versions/draft", req_headers, nil, 404
-      end
+      allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :draft).and_return(api_v3_response_data)
     end
 
     it "finds a form document given a form id and document tag" do
@@ -207,43 +184,69 @@ RSpec.describe Api::V3::FormDocumentRepository do
       expect(form_snapshot.steps).to all be_a Api::V2::StepResource
     end
 
-    it "returns nil if the form does not exist" do
-      expect(described_class.find_with_mode(form_id: "99", mode: Mode.new("preview-draft"))).to be_nil
+    context "when the form document is not found" do
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :draft).and_raise(ActiveResource::ResourceNotFound.new(nil))
+      end
+
+      it "returns nil" do
+        expect(described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"))).to be_nil
+      end
     end
 
     context "when mode is live" do
-      it "returns a live form" do
-        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("live"))
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :live).and_return(api_v3_response_data)
+      end
 
-        expect(form).to have_attributes(form_id: "1", name: "Live form")
+      it "gets a live form document from FormDocumentResource" do
+        described_class.find_with_mode(form_id: 1, mode: Mode.new("live"))
+
+        expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(1, :live)
       end
     end
 
     context "when mode is draft" do
-      it "returns a draft form" do
-        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("preview-draft"))
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :draft).and_return(api_v3_response_data)
+      end
 
-        expect(form).to have_attributes(form_id: "1", name: "Draft form")
+      it "gets a draft form document from FormDocumentResource" do
+        described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"))
+
+        expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(1, :draft)
       end
     end
 
     context "when mode is archived" do
-      it "returns an archived form" do
-        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("preview-archived"))
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :archived).and_return(api_v3_response_data)
+      end
 
-        expect(form).to have_attributes(form_id: "1", name: "Archived form")
+      it "gets an archived form document from FormDocumentResource" do
+        described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-archived"))
+
+        expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(1, :archived)
       end
     end
 
     context "when mode is preview live" do
-      it "returns a live form" do
-        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("preview-live"))
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :live).and_return(api_v3_response_data)
+      end
 
-        expect(form).to have_attributes(form_id: "1", name: "Live form")
+      it "gets a live form document from FormDocumentResource" do
+        described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-live"))
+
+        expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(1, :live)
       end
     end
 
     context "when validating the provided form id" do
+      before do
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).and_return(api_v3_response_data)
+      end
+
       it "returns nil when the id contains non-alpha-numeric chars" do
         expect(described_class.find_with_mode(form_id: "<id>", mode: Mode.new("preview-draft"))).to be_nil
       end
@@ -255,20 +258,32 @@ RSpec.describe Api::V3::FormDocumentRepository do
       it "returns the form when the id is alphanumeric" do
         form = described_class.find_with_mode(form_id: "Alpha123", mode: Mode.new("preview-draft"))
 
-        expect(form).to have_attributes(form_id: "Alpha123", name: "All question types form")
+        expect(form).to have_attributes(name: "All question types form")
       end
     end
 
-    context "when Welsh form requested" do
+    context "when called with a language param" do
       before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v3/forms/1/versions/live?language=cy", req_headers, api_v3_welsh_response_data.to_json, 200
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :draft).and_return(api_v3_response_data)
+        allow(Api::V3::FormDocumentResource).to receive(:find_by_tag).with(1, :draft, language: :cy).and_return(api_v3_welsh_response_data)
+      end
+
+      context "and the language is English" do
+        let(:language) { :en }
+
+        it "does not call the FormDocumentResource with the language param" do
+          described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"), language:)
+          expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(1, :draft)
         end
       end
 
-      it "returns Welsh form document" do
-        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("live"), language: :cy)
-        expect(form).to have_attributes(form_id: "1", name: "Welsh form", language: "cy")
+      context "and the language is Welsh" do
+        let(:language) { :cy }
+
+        it "calls the FormDocumentResource with the language param" do
+          described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"), language:)
+          expect(Api::V3::FormDocumentResource).to have_received(:find_by_tag).with(1, :draft, { language: })
+        end
       end
     end
   end

--- a/spec/services/api/v3/form_document_repository_spec.rb
+++ b/spec/services/api/v3/form_document_repository_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::FormDocumentRepository do
+  let(:req_headers) { { "Accept" => "application/json" } }
+
+  let(:form_id) { "1" }
+  let(:api_v3_response_data) { JSON.load_file("spec/fixtures/all_question_types_form.json") }
+  let(:api_v3_welsh_response_data) { api_v3_response_data.merge(name: "Welsh form", language: "cy") }
+
+  describe ".find_by_tag" do
+    let(:form_id) { "1" }
+    let(:tag) { :live }
+    let(:response_data) { api_v3_response_data.to_json }
+    let(:welsh_response_data) { api_v3_welsh_response_data.to_json }
+    let(:status) { 200 }
+    let(:language) { nil }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/#{form_id}/versions/#{tag}", req_headers, response_data, status
+        mock.get "/api/v3/forms/#{form_id}/versions/#{tag}?language=cy", req_headers, welsh_response_data, status
+      end
+    end
+
+    it "returns form document" do
+      form = described_class.find_by_tag(tag:, form_id:)
+
+      expect(form).to have_attributes(form_id:, name: "All question types form")
+    end
+
+    context "with the archived tag" do
+      let(:tag) { :archived }
+
+      context "when form has been archived" do
+        it "returns an archived form document" do
+          form = described_class.find_by_tag(tag: :archived, form_id: form_id)
+
+          expect(form).to have_attributes(form_id: form_id, name: "All question types form")
+        end
+      end
+
+      context "when a form has not been archived" do
+        let(:response_data) { nil }
+        let(:status) { 404 }
+
+        it "returns nil" do
+          expect(described_class.find_by_tag(tag: :archived, form_id: form_id)).to be_nil
+        end
+      end
+    end
+
+    context "when the form id contains non-alpha-numeric chars" do
+      let(:form_id) { "<id>" }
+
+      it "returns nil when the id contains non-alpha-numeric chars" do
+        expect(described_class.find_by_tag(tag:, form_id:)).to be_nil
+      end
+    end
+
+    context "when the form id is blank" do
+      let(:form_id) { "" }
+
+      it "returns nil when the id is blank" do
+        expect(described_class.find_by_tag(tag:, form_id:)).to be_nil
+      end
+    end
+
+    context "when the form does not exist" do
+      let(:form_id) { "99" }
+      let(:response_data) { nil }
+      let(:status) { 404 }
+
+      it "returns nil" do
+        expect(described_class.find_by_tag(tag:, form_id:)).to be_nil
+      end
+    end
+
+    context "when given language makes correct request" do
+      let(:request_with_no_language_param) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{tag}", req_headers) }
+      let(:request_with_language_param_cy) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{tag}?language=cy", req_headers) }
+
+      before do
+        mock_response = ActiveResource::Response.new(response_data)
+        ActiveResource::HttpMock.respond_to(request_with_no_language_param => mock_response,
+                                            request_with_language_param_cy => mock_response)
+      end
+
+      it "given :en makes request without the language param" do
+        described_class.find_by_tag(tag:, form_id:, language: :en)
+        expect(ActiveResource::HttpMock.requests).to include request_with_no_language_param
+      end
+
+      it "given :cy makes request with the language param" do
+        described_class.find_by_tag(tag:, form_id:, language: :cy)
+        expect(ActiveResource::HttpMock.requests).to include request_with_language_param_cy
+      end
+    end
+  end
+
+  describe ".find_with_mode" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/1/versions/draft", req_headers, api_v3_response_data.merge(name: "Draft form").to_json, 200
+        mock.get "/api/v3/forms/1/versions/live", req_headers, api_v3_response_data.merge(name: "Live form").to_json, 200
+        mock.get "/api/v3/forms/1/versions/archived", req_headers, api_v3_response_data.merge(name: "Archived form").to_json, 200
+        mock.get "/api/v3/forms/2/versions/live", req_headers, nil, 404
+        mock.get "/api/v3/forms/2/versions/archived", req_headers, api_v3_response_data.to_json, 200
+        mock.get "/api/v3/forms/Alpha123/versions/draft", req_headers, api_v3_response_data.merge("form_id": "Alpha123").to_json, 200
+        mock.get "/api/v3/forms/99/versions/draft", req_headers, nil, 404
+      end
+    end
+
+    it "finds a form document given a form id and document tag" do
+      expect(described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"))).to be_truthy
+    end
+
+    it "returns a FormDocumentResource model" do
+      form_snapshot = described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"))
+      expect(form_snapshot).to be_a Api::V3::FormDocumentResource
+      expect(form_snapshot.steps).to all be_a Api::V2::StepResource
+    end
+
+    it "returns nil if the form does not exist" do
+      expect(described_class.find_with_mode(form_id: "99", mode: Mode.new("preview-draft"))).to be_nil
+    end
+
+    context "when mode is live" do
+      it "returns a live form" do
+        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("live"))
+
+        expect(form).to have_attributes(form_id: "1", name: "Live form")
+      end
+    end
+
+    context "when mode is draft" do
+      it "returns a draft form" do
+        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("preview-draft"))
+
+        expect(form).to have_attributes(form_id: "1", name: "Draft form")
+      end
+    end
+
+    context "when mode is archived" do
+      it "returns an archived form" do
+        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("preview-archived"))
+
+        expect(form).to have_attributes(form_id: "1", name: "Archived form")
+      end
+    end
+
+    context "when mode is preview live" do
+      it "returns a live form" do
+        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("preview-live"))
+
+        expect(form).to have_attributes(form_id: "1", name: "Live form")
+      end
+    end
+
+    context "when validating the provided form id" do
+      it "returns nil when the id contains non-alpha-numeric chars" do
+        expect(described_class.find_with_mode(form_id: "<id>", mode: Mode.new("preview-draft"))).to be_nil
+      end
+
+      it "returns nil when the id is blank" do
+        expect(described_class.find_with_mode(form_id: "", mode: Mode.new("preview-draft"))).to be_nil
+      end
+
+      it "returns the form when the id is alphanumeric" do
+        form = described_class.find_with_mode(form_id: "Alpha123", mode: Mode.new("preview-draft"))
+
+        expect(form).to have_attributes(form_id: "Alpha123", name: "All question types form")
+      end
+    end
+
+    context "when Welsh form requested" do
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v3/forms/1/versions/live?language=cy", req_headers, api_v3_welsh_response_data.to_json, 200
+        end
+      end
+
+      it "returns Welsh form document" do
+        form = described_class.find_with_mode(form_id: "1", mode: Mode.new("live"), language: :cy)
+        expect(form).to have_attributes(form_id: "1", name: "Welsh form", language: "cy")
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/form_document_repository_spec.rb
+++ b/spec/services/api/v3/form_document_repository_spec.rb
@@ -97,6 +97,93 @@ RSpec.describe Api::V3::FormDocumentRepository do
     end
   end
 
+  describe ".find_by_version" do
+    let(:form_id) { "1" }
+    let(:version) { 3 }
+    let(:response_data) { api_v3_response_data.to_json }
+    let(:welsh_response_data) { api_v3_welsh_response_data.to_json }
+    let(:status) { 200 }
+    let(:language) { nil }
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v3/forms/#{form_id}/versions/#{version}", req_headers, response_data, status
+        mock.get "/api/v3/forms/#{form_id}/versions/#{version}?language=cy", req_headers, welsh_response_data, status
+      end
+    end
+
+    it "returns form document" do
+      form = described_class.find_by_version(version:, form_id:)
+
+      expect(form).to have_attributes(form_id:, name: "All question types form")
+    end
+
+    context "when the form id contains non-alpha-numeric chars" do
+      let(:form_id) { "<id>" }
+
+      it "returns nil when the id contains non-alpha-numeric chars" do
+        expect(described_class.find_by_version(version:, form_id:)).to be_nil
+      end
+    end
+
+    context "when the version id contains non-numeric chars" do
+      let(:version) { "a" }
+
+      it "returns nil when the id contains non-alpha-numeric chars" do
+        expect(described_class.find_by_version(version:, form_id:)).to be_nil
+      end
+    end
+
+    context "when the form id is blank" do
+      let(:form_id) { "" }
+
+      it "returns nil when the id is blank" do
+        expect(described_class.find_by_version(version:, form_id:)).to be_nil
+      end
+    end
+
+    context "when the form does not exist" do
+      let(:form_id) { "99" }
+      let(:response_data) { nil }
+      let(:status) { 404 }
+
+      it "returns nil" do
+        expect(described_class.find_by_version(version:, form_id:)).to be_nil
+      end
+    end
+
+    context "when the version does not exist" do
+      let(:version) { 5 }
+      let(:response_data) { nil }
+      let(:status) { 404 }
+
+      it "returns nil" do
+        expect(described_class.find_by_version(version:, form_id:)).to be_nil
+      end
+    end
+
+    context "when given language makes correct request" do
+      let(:request_with_no_language_param) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{version}", req_headers) }
+      let(:request_with_language_param_cy) { ActiveResource::Request.new(:get, "/api/v3/forms/#{form_id}/versions/#{version}?language=cy", req_headers) }
+
+      before do
+        mock_response = ActiveResource::Response.new(response_data)
+        ActiveResource::HttpMock.respond_to(request_with_no_language_param => mock_response,
+                                            request_with_language_param_cy => mock_response)
+      end
+
+      it "given :en makes request without the language param" do
+        described_class.find_by_version(version:, form_id:, language: :en)
+        expect(ActiveResource::HttpMock.requests).to include request_with_no_language_param
+      end
+
+      it "given :cy makes request with the language param" do
+        described_class.find_by_version(version:, form_id:, language: :cy)
+        expect(ActiveResource::HttpMock.requests).to include request_with_language_param_cy
+      end
+    end
+  end
+
   describe ".find_with_mode" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/P7bDQZTP/3248-get-submission-delivery-configuration-from-latest-live-version-of-the-form-in-forms-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds new resources for interacting with the v3 form document API.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
