### PR TITLE
Use `declaration_markdown` only for form declarations

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,6 +6,7 @@ class Form
   end
 
   delegate :declaration_text,
+           :declaration_markdown,
            :form_id,
            :form_slug,
            :name,
@@ -71,10 +72,6 @@ class Form
 
   def available_languages
     form_document.try(:available_languages) || []
-  end
-
-  def declaration_markdown
-    form_document.try(:declaration_markdown)
   end
 
   def has_custom_branding?

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -57,15 +57,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <% if @current_context.form.try(:declaration_markdown).present? %>
+      <% declaration_present = @current_context.form.declaration_markdown.present? %>
+
+      <% if declaration_present %>
         <h2 class="govuk-heading-m govuk-!-margin-top-7"><%= t('form.check_your_answers.declaration') %></h2>
         <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@current_context.form.declaration_markdown) %>
-      <% elsif @current_context.form.declaration_text.present? %>
-        <h2 class="govuk-heading-m govuk-!-margin-top-7"><%= t('form.check_your_answers.declaration') %></h2>
-        <%= HtmlMarkdownSanitizer.new.render_scrubbed_html(@current_context.form.declaration_text) %>
       <% end %>
 
-      <% declaration_present = @current_context.form.try(:declaration_markdown).present? || @current_context.form.declaration_text.present? %>
       <%= form.govuk_submit(declaration_present ? t('form.check_your_answers.agree_and_submit') : t('form.check_your_answers.submit')) %>
     </div>
   </div>

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     payment_url { nil }
     language { "en" }
     declaration_text { nil }
+    declaration_markdown { nil }
     brand_id { nil }
 
     s3_bucket_name { nil }

--- a/spec/factories/v2_form_document.rb
+++ b/spec/factories/v2_form_document.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     steps { [] }
 
     declaration_text { nil }
+    declaration_markdown { nil }
     payment_url { nil }
     privacy_policy_url { nil }
     submission_email { nil }

--- a/spec/fixtures/all_question_types_form.json
+++ b/spec/fixtures/all_question_types_form.json
@@ -8,21 +8,36 @@
   "support_phone": "08000800",
   "support_url": null,
   "support_url_text": null,
-  "declaration_text": "",
-  "created_at": "2024-09-05T06:25:25.558Z",
-  "updated_at": "2024-09-05T06:25:25.637Z",
+  "declaration_text": null,
+  "created_at": "2026-08-25T10:38:30.171303Z",
+  "updated_at": "2026-08-25T10:38:30.261912Z",
   "creator_id": null,
-  "organisation_id": 1,
   "what_happens_next_markdown": "Test",
   "payment_url": null,
-  "start_page": 1,
+  "start_page": "uDdxskFA",
   "language": "en",
   "available_languages": ["en", "cy"],
+  "s3_bucket_name": null,
+  "s3_bucket_region": null,
+  "s3_bucket_aws_account_id": null,
+  "first_made_live_at": "2026-08-25T10:38:30.257406Z",
+  "copied_from_id": null,
+  "declaration_markdown": null,
+  "send_copy_of_answers": "disabled",
+  "brand_id": null,
+  "delivery_configurations": [
+    {
+      "formats": [
+      ],
+      "delivery_method": "email",
+      "delivery_schedule": "immediate"
+    }
+  ],
   "steps": [
     {
-      "id": 1,
+      "id": "uDdxskFA",
       "position": 1,
-      "next_step_id": 2,
+      "next_step_id": "kahErwcC",
       "type": "question",
       "data": {
         "question_text": "Single line of text",
@@ -36,12 +51,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 2,
+      "id": "kahErwcC",
       "position": 2,
-      "next_step_id": 3,
+      "next_step_id": "5aTmmjSR",
       "type": "question",
       "data": {
         "question_text": "Number",
@@ -53,12 +69,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 3,
+      "id": "5aTmmjSR",
       "position": 3,
-      "next_step_id": 4,
+      "next_step_id": "DcVvTbpD",
       "type": "question",
       "data": {
         "question_text": "Address",
@@ -75,12 +92,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 4,
+      "id": "DcVvTbpD",
       "position": 4,
-      "next_step_id": 5,
+      "next_step_id": "RfUfTEqu",
       "type": "question",
       "data": {
         "question_text": "Email address",
@@ -92,12 +110,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 5,
+      "id": "RfUfTEqu",
       "position": 5,
-      "next_step_id": 6,
+      "next_step_id": "KtuPUign",
       "type": "question",
       "data": {
         "question_text": "Todays Date",
@@ -111,12 +130,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 6,
+      "id": "KtuPUign",
       "position": 6,
-      "next_step_id": 7,
+      "next_step_id": "4b9kztBN",
       "type": "question",
       "data": {
         "question_text": "National Insurance number",
@@ -128,12 +148,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 7,
+      "id": "4b9kztBN",
       "position": 7,
-      "next_step_id": 8,
+      "next_step_id": "L5oYHqFU",
       "type": "question",
       "data": {
         "question_text": "Phone number",
@@ -145,12 +166,13 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 8,
+      "id": "L5oYHqFU",
       "position": 8,
-      "next_step_id": 9,
+      "next_step_id": "PWjgyvkU",
       "type": "question",
       "data": {
         "question_text": "Selection from a list of options",
@@ -158,16 +180,19 @@
         "answer_type": "selection",
         "is_optional": true,
         "answer_settings": {
-          "only_one_option": "0",
+          "only_one_option": "false",
           "selection_options": [
             {
-              "name": "Option 1"
+              "name": "Option 1",
+              "value": "Option 1"
             },
             {
-              "name": "Option 2"
+              "name": "Option 2",
+              "value": "Option 2"
             },
             {
-              "name": "Option 3"
+              "name": "Option 3",
+              "value": "Option 3"
             }
           ]
         },
@@ -175,10 +200,11 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     },
     {
-      "id": 9,
+      "id": "PWjgyvkU",
       "position": 9,
       "next_step_id": null,
       "type": "question",
@@ -194,6 +220,7 @@
         "guidance_markdown": null,
         "is_repeatable": false
       },
+      "exit_pages": [],
       "routing_conditions": []
     }
   ]

--- a/spec/lib/flow/context_spec.rb
+++ b/spec/lib/flow/context_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flow::Context do
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps:)
   end
   let(:form) { Form.new(form_document) }

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Forms::BaseController, type: :request do
       start_page:,
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
       what_happens_next_markdown: "Good things come to those that wait",
-      declaration_text: "agree to the declaration",
+      declaration_markdown: "agree to the declaration",
       steps: steps_data,
       language:,
     )

--- a/spec/requests/forms/branded_accessibility_statement_controller_spec.rb
+++ b/spec/requests/forms/branded_accessibility_statement_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Forms::BrandedAccessibilityStatementController, type: :request do
           id: 2,
           start_page: 1,
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data,
           brand_id: "weatherfield")
   end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Forms::CheckYourAnswersController, :capture_logging, type: :reque
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data,
           support_phone: "0203 222 2222",
           support_email: "help@example.gov.uk",

--- a/spec/requests/forms/privacy_page_controller_spec.rb
+++ b/spec/requests/forms/privacy_page_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::PrivacyPageController, type: :request do
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data)
   end
 

--- a/spec/requests/forms/remove_file_controller_spec.rb
+++ b/spec/requests/forms/remove_file_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data)
   end
 

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::ReviewFileController, type: :request do
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data)
   end
 

--- a/spec/requests/forms/selection_none_of_the_above_controller_spec.rb
+++ b/spec/requests/forms/selection_none_of_the_above_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Forms::SelectionNoneOfTheAboveController, type: :request do
           start_page: text_question_step.id,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data)
   end
 

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
           start_page: first_step_id,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           available_languages:,
           send_copy_of_answers:,
           steps: steps_data)
@@ -64,7 +64,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
       build(:v2_form_document, :with_support,
             id: 200,
             start_page: step_id,
-            declaration_text: "agree to the declaration",
+            declaration_markdown: "agree to the declaration",
             steps: [
               build(:v2_question_step, :with_text_settings,
                     id: step_id,

--- a/spec/requests/forms/submitted_controller_spec.rb
+++ b/spec/requests/forms/submitted_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::SubmittedController, type: :request do
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Your application will be processed within a few days.\n\nContact us if you need to:\n\n-change the details of your application\n-cancel your application",
-          declaration_text: "agree to the declaration",
+          declaration_markdown: "agree to the declaration",
           steps: steps_data)
   end
 

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -33,14 +33,14 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   context "when the form has a declaration" do
-    let(:declaration_text) { "You should agree to all terms before submitting" }
+    let(:declaration_markdown) { "This is the markdown decalaration\n\nsecond paragraph" }
 
     it "displays the declaration heading" do
       expect(rendered).to have_css("h2", text: "Declaration")
     end
 
-    it "displays declaration text" do
-      expect(rendered).to have_css("p", text: form.declaration_text)
+    it "displays declaration markdown" do
+      expect(rendered).to have_css("p", text: "second paragraph")
     end
   end
 
@@ -62,14 +62,15 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   context "when the form has a markdown declaration only" do
-    let(:declaration_markdown) { "This is the markdown decalaration\n\nsecond paragraph" }
+    let(:declaration_text) { "You should agree to all terms before submitting" }
+    let(:declaration_markdown) { nil }
 
-    it "displays the declaration heading" do
-      expect(rendered).to have_css("h2", text: "Declaration")
+    it "does not display the declaration heading" do
+      expect(rendered).not_to have_css("h2", text: "Declaration")
     end
 
-    it "displays declaration markdown" do
-      expect(rendered).to have_css("p", text: "second paragraph")
+    it "does not display declaration text" do
+      expect(rendered).not_to have_css("p", text: form.declaration_text)
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Fixes issue reported by user in Zendesk ticket https://govuk.zendesk.com/agent/tickets/6829206.

As of May 2026 all form documents now have a `declaration_markdown` property (confirmed using `gds aws forms-prod-support -- forms data_api -d forms-admin -s $'SELECT COUNT(*) FROM form_documents WHERE NOT content ? \'declaration_markdown\';'`), and the `declaration_text` property is no longer updated (see govuk-forms/forms-admin#2620).

However, form documents can still have the `declaration_text` property, and some form documents have no declaration (blank `declaration_markdown`) but a non-blank `declaration_text`.

To stop a declaration from being shown in this scenario, this PR removes the code that showed the contents of `declaration_text`. We also update all specs to use `declaration_markdown`.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
